### PR TITLE
Major refactoring around objects and DB API

### DIFF
--- a/procession/api/resources.py
+++ b/procession/api/resources.py
@@ -21,12 +21,12 @@ import jsonschema
 from oslo.config import cfg
 
 from procession import exc
+from procession import objects
 from procession.db import api as db_api
 from procession.db import session as db_session
 from procession.api import auth
 from procession.api import context
 from procession.api import helpers
-from procession.api import objects
 from procession.api import search
 
 CONF = cfg.CONF
@@ -71,7 +71,7 @@ class OrganizationsResource(object):
         ctx = context.from_request(req)
         to_add = helpers.deserialize(req)
         try:
-            to_add = objects.Organization(to_add)
+            to_add = objects.Organization.from_py_object(to_add)
         except jsonschema.ValidationError as e:
             resp.body = "Bad input: {0}".format(e)
             resp.status = falcon.HTTP_400

--- a/procession/db/models.py
+++ b/procession/db/models.py
@@ -285,30 +285,33 @@ class Organization(ModelBase):
     __tablename__ = 'organizations'
     __table_args__ = (
         ModelBase.__table_args__,
-        schema.UniqueConstraint('org_name', 'parent_organization_id',
-                                name="uc_org_name_in_root"),
-        schema.UniqueConstraint('root_organization_id', 'left_sequence',
-                                'right_sequence', name="uc_nested_set_shard")
+        schema.UniqueConstraint('name', 'parent_organization_id',
+                                name="uc_name_in_org_tree"),
+        # NOTE(jaypipes): Note that this is not a UniqueConstraint because of
+        # the special root_organization_id column. This column is set to zero
+        # when a new organization is created. Immediately after the create, the
+        # root_organization_id is then set to the integer sequence that is set
+        # on the id column. Because there is a chance that two organization
+        # records could be created in quick succession, both with a temporary
+        # root_organization_id of zero, which would violate the unique
+        # constraint.
+        schema.Index('uc_nested_set_shard', 'root_organization_id',
+                     'left_sequence', 'right_sequence'),
+        schema.Index('ix_parent_organization', 'parent_organization_id')
     )
-    _required = ('org_name', 'display_name')
+    _required = ('name', 'display_name')
     _default_order_by = [
         ('slug', 'asc'),
     ]
-    id = schema.Column(GUID, primary_key=True, default=uuid.uuid4)
+    id = schema.Column(types.Integer, primary_key=True)
     display_name = schema.Column(CoerceUTF8(50), nullable=False)
-    org_name = schema.Column(CoerceUTF8(30), nullable=False)
+    name = schema.Column(CoerceUTF8(30), nullable=False)
     slug = schema.Column(types.String(100), nullable=False,
                          unique=True, index=True)
     created_on = schema.Column(types.DateTime, nullable=False,
                                default=datetime.datetime.utcnow)
-    # NOTE(jaypipes): We don't index root_organization_id separately
-    #                 because it is the left-most column in the unique
-    #                 constraint on:
-    #                 (root_org_id, left_sequence, right_sequence)
-    #                 and therefore functions as a single-column index
-    #                 on root_organization_id.
-    root_organization_id = schema.Column(GUID, nullable=False)
-    parent_organization_id = schema.Column(GUID, nullable=True, index=True)
+    root_organization_id = schema.Column(types.Integer, nullable=False)
+    parent_organization_id = schema.Column(types.Integer, nullable=True)
     left_sequence = schema.Column(types.Integer, nullable=False)
     right_sequence = schema.Column(types.Integer, nullable=False)
     groups = orm.relationship("Group",
@@ -337,39 +340,43 @@ class Organization(ModelBase):
 
             `session`: A session object to use
         """
-        sess = kwargs.get('session', session.get_session())
-        conn = sess.connection()
         org_table = self.__table__
         slug_col_len = org_table.c.slug.type.length
         slug_prefix = ''
         if self.parent_organization_id is not None:
+            sess = kwargs.get('session', session.get_session())
+            conn = sess.connection()
             where_expr = org_table.c.id == self.parent_organization_id
             sel = expr.select([org_table.c.slug]).where(where_expr)
             parent = conn.execute(sel).fetchone()
             slug_prefix = parent[0] + '-'
-        to_slug = slug_prefix + self.org_name
+        to_slug = slug_prefix + self.name
         self.slug = slugify.slugify(to_slug, max_length=slug_col_len)
+
+    def __repr__(self):
+        return "<Org {0} '{1}'>".format(self.id, self.name)
 
 
 class Group(ModelBase):
     __tablename__ = 'groups'
     __table_args__ = (
         ModelBase.__table_args__,
-        schema.UniqueConstraint('root_organization_id', 'group_name',
-                                name='uc_root_org_group_name')
+        schema.UniqueConstraint('root_organization_id', 'name',
+                                name='uc_root_org_name')
     )
-    _required = ('group_name', 'display_name', 'root_organization_id')
+    _required = ('name', 'display_name', 'root_organization_id')
     _default_order_by = [
         ('root_organization_id', 'asc'),
-        ('group_name', 'asc'),
+        ('name', 'asc'),
     ]
-    id = schema.Column(GUID, primary_key=True)
+    id = schema.Column(types.Integer, primary_key=True)
     root_organization_id = schema.Column(
-        GUID, schema.ForeignKey('organizations.id',
-                                onupdate="CASCADE", ondelete="CASCADE"),
+        types.Integer, schema.ForeignKey('organizations.id',
+                                         onupdate="CASCADE",
+                                         ondelete="CASCADE"),
         nullable=False)
     display_name = schema.Column(CoerceUTF8(60), nullable=False)
-    group_name = schema.Column(CoerceUTF8(30), nullable=False)
+    name = schema.Column(CoerceUTF8(30), nullable=False)
     slug = schema.Column(types.String(100), nullable=False,
                          unique=True, index=True)
     created_on = schema.Column(types.DateTime, nullable=False,
@@ -404,21 +411,25 @@ class Group(ModelBase):
         sel = expr.select([org_table.c.slug]).where(where_expr)
         root = conn.execute(sel).fetchone()
         slug_prefix = root[0] + '-'
-        to_slug = slug_prefix + self.group_name
+        to_slug = slug_prefix + self.name
         self.slug = slugify.slugify(to_slug, max_length=slug_col_len)
+
+    def __repr__(self):
+        res = "<Group {0} '{1}' (in Org: {2})>"
+        return res.format(self.id, self.name, self.root_organization_id)
 
 
 class User(ModelBase):
     __tablename__ = 'users'
-    _required = ('email', 'user_name', 'display_name')
-    _slug_from = ('user_name',)
+    _required = ('email', 'name', 'display_name')
+    _slug_from = ('name',)
     _default_order_by = [
         ('created_on', 'desc'),
     ]
-    id = schema.Column(GUID, primary_key=True, default=uuid.uuid4)
+    id = schema.Column(types.Integer, primary_key=True)
     display_name = schema.Column(CoerceUTF8(50), nullable=False)
-    user_name = schema.Column(CoerceUTF8(30), nullable=False,
-                              unique=True, index=True)
+    name = schema.Column(CoerceUTF8(30), nullable=False,
+                         unique=True, index=True)
     slug = schema.Column(types.String(40), nullable=False,
                          unique=True, index=True)
     email = schema.Column(types.String(80), nullable=False,
@@ -440,9 +451,10 @@ class UserPublicKey(ModelBase):
     _default_order_by = [
         ('created_on', 'desc'),
     ]
-    user_id = schema.Column(GUID, schema.ForeignKey('users.id',
-                                                    onupdate="CASCADE",
-                                                    ondelete="CASCADE"),
+    user_id = schema.Column(types.Integer,
+                            schema.ForeignKey('users.id',
+                                              onupdate="CASCADE",
+                                              ondelete="CASCADE"),
                             primary_key=True)
     fingerprint = schema.Column(Fingerprint, primary_key=True)
     public_key = schema.Column(types.Text, nullable=False)
@@ -452,13 +464,15 @@ class UserPublicKey(ModelBase):
 
 class UserGroupMembership(ModelBase):
     __tablename__ = 'user_group_memberships'
-    user_id = schema.Column(GUID, schema.ForeignKey('users.id',
-                                                    onupdate="CASCADE",
-                                                    ondelete="CASCADE"),
+    user_id = schema.Column(types.Integer,
+                            schema.ForeignKey('users.id',
+                                              onupdate="CASCADE",
+                                              ondelete="CASCADE"),
                             primary_key=True)
-    group_id = schema.Column(GUID, schema.ForeignKey('groups.id',
-                                                     onupdate="CASCADE",
-                                                     ondelete="CASCADE"),
+    group_id = schema.Column(types.Integer,
+                             schema.ForeignKey('groups.id',
+                                               onupdate="CASCADE",
+                                               ondelete="CASCADE"),
                              primary_key=True)
 
 
@@ -499,7 +513,7 @@ class Domain(ModelBase):
     VISIBILITY_RESTRICTED = 2
     """The domain is visible to the owner and anyone the owner shares with"""
 
-    id = schema.Column(GUID, primary_key=True, default=uuid.uuid4)
+    id = schema.Column(types.Integer, primary_key=True)
     name = schema.Column(CoerceUTF8(50), nullable=False)
     slug = schema.Column(types.String(60), nullable=False, unique=True,
                          index=True)
@@ -507,11 +521,11 @@ class Domain(ModelBase):
                                default=datetime.datetime.utcnow)
     visibility = schema.Column(types.Integer, nullable=False,
                                default=VISIBILITY_ALL)
-    owner_id = schema.Column(
-        GUID, schema.ForeignKey('users.id',
-                                onupdate="CASCADE",
-                                ondelete="CASCADE"),
-        nullable=False)
+    owner_id = schema.Column(types.Integer,
+                             schema.ForeignKey('users.id',
+                                               onupdate="CASCADE",
+                                               ondelete="CASCADE"),
+                             nullable=False)
     repositories = orm.relationship("Repository", backref="domain",
                                     cascade="all, delete-orphan")
 
@@ -539,18 +553,18 @@ class Repository(ModelBase):
     _default_order_by = [
         ('created_on', 'desc'),
     ]
-    id = schema.Column(GUID, primary_key=True, default=uuid.uuid4)
-    domain_id = schema.Column(
-        GUID, schema.ForeignKey('domains.id',
-                                onupdate="CASCADE",
-                                ondelete="CASCADE"),
-        nullable=False)
+    id = schema.Column(types.Integer, primary_key=True)
+    domain_id = schema.Column(types.Integer,
+                              schema.ForeignKey('domains.id',
+                                                onupdate="CASCADE",
+                                                ondelete="CASCADE"),
+                              nullable=False)
     name = schema.Column(CoerceUTF8(50), nullable=False)
-    owner_id = schema.Column(
-        GUID, schema.ForeignKey('users.id',
-                                onupdate="CASCADE",
-                                ondelete="CASCADE"),
-        nullable=False)
+    owner_id = schema.Column(types.Integer,
+                             schema.ForeignKey('users.id',
+                                               onupdate="CASCADE",
+                                               ondelete="CASCADE"),
+                             nullable=False)
     created_on = schema.Column(types.DateTime, nullable=False,
                                default=datetime.datetime.utcnow, index=True)
 
@@ -599,19 +613,19 @@ class Changeset(ModelBase):
     STATE_MERGED = 12
     """A state indicating the code has been merged into the target branch"""
 
-    id = schema.Column(GUID, primary_key=True, default=uuid.uuid4)
-    target_repo_id = schema.Column(
-        GUID, schema.ForeignKey('repositories.id',
-                                onupdate="CASCADE",
-                                ondelete="CASCADE"),
-        nullable=False)
+    id = schema.Column(types.Integer, primary_key=True)
+    target_repo_id = schema.Column(types.Integer,
+                                   schema.ForeignKey('repositories.id',
+                                                     onupdate="CASCADE",
+                                                     ondelete="CASCADE"),
+                                   nullable=False)
     target_branch = schema.Column(types.String(200), nullable=False)
     state = schema.Column(types.Integer, nullable=False)
-    uploaded_by = schema.Column(
-        GUID, schema.ForeignKey('users.id',
-                                onupdate="CASCADE",
-                                ondelete="CASCADE"),
-        nullable=False)
+    uploaded_by = schema.Column(types.Integer,
+                                schema.ForeignKey('users.id',
+                                                  onupdate="CASCADE",
+                                                  ondelete="CASCADE"),
+                                nullable=False)
     commit_message = schema.Column(types.Text)
     created_on = schema.Column(types.DateTime, nullable=False,
                                default=datetime.datetime.utcnow)
@@ -637,17 +651,17 @@ class Change(ModelBase):
     _default_order_by = [
         ('created_on', 'desc'),
     ]
-    changeset_id = schema.Column(
-        GUID, schema.ForeignKey('changesets.id',
-                                onupdate="CASCADE",
-                                ondelete="CASCADE"),
-        primary_key=True)
+    changeset_id = schema.Column(types.Integer,
+                                 schema.ForeignKey('changesets.id',
+                                                   onupdate="CASCADE",
+                                                   ondelete="CASCADE"),
+                                 primary_key=True)
     sequence = schema.Column(types.Integer, primary_key=True)
-    uploaded_by = schema.Column(
-        GUID, schema.ForeignKey('users.id',
-                                onupdate="CASCADE",
-                                ondelete="CASCADE"),
-        nullable=False)
+    uploaded_by = schema.Column(types.Integer,
+                                schema.ForeignKey('users.id',
+                                                  onupdate="CASCADE",
+                                                  ondelete="CASCADE"),
+                                nullable=False)
     created_on = schema.Column(types.DateTime, nullable=False,
                                default=datetime.datetime.utcnow)
 

--- a/procession/helpers.py
+++ b/procession/helpers.py
@@ -15,7 +15,62 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import json
 import uuid
+import yaml
+
+
+def serialize_json(subject):
+    """
+    Returns a JSON-serialized string representing the supplied dict or
+    list of dicts.
+
+    :param subject: dict or list of dicts to serialize
+    """
+    return json.dumps(subject, 'utf-8')
+
+
+def serialize_yaml(subject):
+    """
+    Returns a JSON-serialized string representing the supplied dict or
+    list of dicts.
+
+    :param subject: dict or list of dicts to serialize
+    """
+    return yaml.dump(subject)
+
+
+def deserialize_json(subject):
+    """
+    Returns a dict or list of dicts that is deserialized from the supplied
+    raw string.
+
+    :param subject: String to deserialize
+    """
+    return json.loads(subject, 'utf-8')
+
+
+def deserialize_yaml(subject):
+    """
+    Returns a dict or list of dicts that is deserialized from the supplied
+    raw string.
+
+    :param subject: String to deserialize
+    """
+    # yaml.load() assumes subject is a UTF-8 encoded str
+    return yaml.load(subject)
+
+
+def is_like_int(subject):
+    """
+    Returns True if the subject resembles an integer, False otherwise.
+    """
+    if isinstance(subject, int):
+        return True
+    try:
+        return str(int(subject)) == subject
+    except (TypeError, ValueError, AttributeError):
+        return False
 
 
 def is_like_uuid(subject):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ pbr>=0.5,<0.6
 
 falcon
 jsonschema
-jsonpatch
 oslo.config>=1.1.0
 pyyaml
 python-slugify

--- a/tests/api/test_helpers.py
+++ b/tests/api/test_helpers.py
@@ -24,7 +24,7 @@ from tests import fakes
 from tests import base
 
 
-class TestApiHelpers(base.UnitTest):
+class TestSerializers(base.UnitTest):
 
     def json_request(self, contents):
         req = mock.MagicMock()
@@ -33,16 +33,6 @@ class TestApiHelpers(base.UnitTest):
         req.body = mock.MagicMock()
         req.body.read.return_value = contents
         return req
-
-    def test_deserialize_bad_json(self):
-        with testtools.ExpectedException(fexc.HTTPBadRequest):
-            blob = "{asl12^ak"
-            helpers.deserialize_json(blob)
-
-    def test_deserialize_bad_yaml(self):
-        with testtools.ExpectedException(fexc.HTTPBadRequest):
-            blob = "{asl12^ak"
-            helpers.deserialize_yaml(blob)
 
     def test_serialize_bad_mime_type(self):
         req = mock.MagicMock()

--- a/tests/db/test_api.py
+++ b/tests/db/test_api.py
@@ -14,11 +14,18 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+# NOTE: These particular unit tests are more than just unit tests. It is partly
+# a functional test of the DB API layer as well, since mocking out all of
+# SQLAlchemy was not particularly nice, nor all that useful in identifying
+# bugs. So, these tests do actually execute the various database queries
+# against an SQLite database backend and verify things like transaction safety.
+
 import mock
 import testtools
 from testtools import matchers
 
 from procession import exc
+from procession import objects
 from procession.db import api
 from procession.db import session
 
@@ -28,76 +35,54 @@ from tests import fakes
 
 class TestDbApi(base.UnitTest):
 
-    # Note that this particular unit test is more than just a unit test. It
-    # is partly a functional test of the DB API layer as well, since mocking
-    # out all of SQLAlchemy was not particularly nice, nor all that useful
-    # in identifying bugs. So, these tests do actually execute the various
-    # database queries against an SQLite database backend and verify things
-    # like transaction safety.
-
     def setUp(self):
         super(TestDbApi, self).setUp()
         self.sess = session.get_session()
 
-    def test_org_create_bad_data(self):
-        ctx = mock.Mock()
-        org_info = {}
-        with testtools.ExpectedException(ValueError):
-            api.organization_create(ctx, org_info)
+    def _new_org(self, values):
+        """
+        Return a new org based on a supplied dict of field values.
+        """
+        return objects.Organization.from_py_object(values)
 
-    def test_org_delete_bad_input(self):
-        ctx = mock.Mock()
-        org_id = 'notauuid'
-        with testtools.ExpectedException(exc.BadInput):
-            api.organization_delete(ctx, org_id, session=self.sess)
+    def _new_group(self, values):
+        """
+        Return a new org based on a supplied dict of field values.
+        """
+        return objects.Group.from_py_object(values)
+
+
+class TestOrganizations(TestDbApi):
 
     def test_org_delete_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.organization_delete(ctx, fakes.FAKE_UUID1, session=self.sess)
-
-    def test_org_create_invalid_attr(self):
-        ctx = mock.Mock()
-        org_info = {
-            'display_name': 'foo org display',
-            'org_name': 'foo org',
-            'notanattr': True
-        }
-        with testtools.ExpectedException(TypeError):
-            api.organization_create(ctx, org_info, session=self.sess)
+            api.organization_delete(ctx, 9999, session=self.sess)
 
     def test_org_create_parent_not_found(self):
         ctx = mock.Mock()
         org_info = {
             'display_name': 'foo org display',
-            'org_name': 'foo org',
-            'parent_organization_id': fakes.FAKE_UUID1
+            'name': 'foo org',
+            'parent_organization_id': 9999
         }
+        org = self._new_org(org_info)
         with testtools.ExpectedException(exc.NotFound):
-            api.organization_create(ctx, org_info, session=self.sess)
-
-    def test_org_create_parent_invalid(self):
-        ctx = mock.Mock()
-        org_info = {
-            'display_name': 'foo org display',
-            'org_name': 'foo org',
-            'parent_organization_id': 'baduuid'
-        }
-        with testtools.ExpectedException(exc.BadInput):
-            api.organization_create(ctx, org_info, session=self.sess)
+            api.organization_create(ctx, org, session=self.sess)
 
     def test_org_crud(self):
         ctx = mock.Mock()
         org_info = {
             'display_name': 'root 1 display',
-            'org_name': 'root 1 org'
+            'name': 'root 1 org'
         }
-        ro1 = api.organization_create(ctx, org_info, session=self.sess)
+        org1 = self._new_org(org_info)
+        ro1 = api.organization_create(ctx, org1, session=self.sess)
         self.assertIsNotNone(ro1.id)
         ro1_id = ro1.id
 
         with testtools.ExpectedException(exc.Duplicate):
-            api.organization_create(ctx, org_info, session=self.sess)
+            api.organization_create(ctx, org1, session=self.sess)
 
         self.assertEquals(ro1.display_name, org_info['display_name'])
         self.assertEquals(ro1.parent_organization_id, None)
@@ -107,10 +92,11 @@ class TestDbApi(base.UnitTest):
         # organization is set correctly.
         org_info = {
             'display_name': 'root 1-a display',
-            'org_name': 'root 1-a org',
+            'name': 'root 1-a org',
             'parent_organization_id': ro1_id
         }
-        ro1a = api.organization_create(ctx, org_info, session=self.sess)
+        org1a = self._new_org(org_info)
+        ro1a = api.organization_create(ctx, org1a, session=self.sess)
         ro1a_id = ro1a.id
 
         self.assertEquals(ro1a.root_organization_id, ro1_id)
@@ -127,30 +113,27 @@ class TestDbApi(base.UnitTest):
         # the same organization name raises a Duplicate but that we can
         # still create an organization in a different root organization
         # with the same org name.
-        org_info = {
-            'display_name': 'root 1-a display',
-            'org_name': 'root 1-a org',
-            'parent_organization_id': ro1_id
-        }
         with testtools.ExpectedException(exc.Duplicate):
-            api.organization_create(ctx, org_info, session=self.sess)
+            api.organization_create(ctx, org1a, session=self.sess)
 
         # Add a child organization and verify that the root
         # organization is set correctly.
         org_info = {
             'display_name': 'root 2 display',
-            'org_name': 'root 2 org'
+            'name': 'root 2 org'
         }
-        ro2 = api.organization_create(ctx, org_info, session=self.sess)
+        org2 = self._new_org(org_info)
+        ro2 = api.organization_create(ctx, org2, session=self.sess)
         ro2_id = ro2.id
         self.addCleanup(api.organization_delete, ctx, ro2_id,
                         session=self.sess)
         org_info = {
             'display_name': 'root 1-a display',
-            'org_name': 'root 1-a org',  # Same name as ro1a, but diff root
+            'name': 'root 1-a org',  # Same name as ro1a, but diff root
             'parent_organization_id': ro2_id
         }
-        ro2a = api.organization_create(ctx, org_info, session=self.sess)
+        org2a = self._new_org(org_info)
+        ro2a = api.organization_create(ctx, org2a, session=self.sess)
         self.assertEquals(ro2a.parent_organization_id, ro2_id)
 
         api.organization_delete(ctx, ro1_id, session=self.sess)
@@ -211,14 +194,15 @@ class TestDbApi(base.UnitTest):
 
         for o_name, org_dict in sorted(orgs.items()):
             org_info = {
-                'org_name': o_name,
+                'name': o_name,
                 'display_name': o_name
             }
             if 'parent' in org_dict:
                 parent = org_dict['parent']
                 org_info['parent_organization_id'] = orgs[parent]['obj'].id
 
-            o = api.organization_create(ctx, org_info, session=self.sess)
+            org = self._new_org(org_info)
+            o = api.organization_create(ctx, org, session=self.sess)
             orgs[o_name]['obj'] = o
 
         spec = fakes.get_search_spec(limit=20)
@@ -254,141 +238,102 @@ class TestDbApi(base.UnitTest):
     def test_org_get_by_pk_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.organization_get_by_pk(ctx, fakes.FAKE_UUID1,
+            api.organization_get_by_pk(ctx, 9999,
                                        session=self.sess)
-
-    def test_group_create_bad_data(self):
-        ctx = mock.Mock()
-        group_info = {}
-        with testtools.ExpectedException(ValueError):
-            api.group_create(ctx, group_info)
-
-    def test_group_delete_bad_input(self):
-        ctx = mock.Mock()
-        group_id = 'notauuid'
-        with testtools.ExpectedException(exc.BadInput):
-            api.group_delete(ctx, group_id, session=self.sess)
 
     def test_group_delete_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.group_delete(ctx, fakes.FAKE_UUID1, session=self.sess)
-
-    def test_group_create_invalid_attr(self):
-        ctx = mock.Mock()
-        group_info = {
-            'display_name': 'foo group display',
-            'group_name': 'foo group',
-            'root_organization_id': fakes.FAKE_UUID1,
-            'notanattr': True
-        }
-        with testtools.ExpectedException(TypeError):
-            api.group_create(ctx, group_info, session=self.sess)
+            api.group_delete(ctx, 9999, session=self.sess)
 
     def test_group_create_root_not_root(self):
         ctx = mock.Mock()
         org_info = {
             'display_name': 'root 1 display',
-            'org_name': 'root 1 org'
+            'name': 'root 1 org'
         }
-        ro1 = api.organization_create(ctx, org_info, session=self.sess)
+        org1 = self._new_org(org_info)
+        ro1 = api.organization_create(ctx, org1, session=self.sess)
         ro1_id = ro1.id
         self.addCleanup(api.organization_delete, ctx, ro1_id,
                         session=self.sess)
 
         org_info = {
             'display_name': 'root 1-a display',
-            'org_name': 'root 1-a org',
+            'name': 'root 1-a org',
             'parent_organization_id': ro1_id
         }
-        ro1a = api.organization_create(ctx, org_info, session=self.sess)
+        org1a = self._new_org(org_info)
+        ro1a = api.organization_create(ctx, org1a, session=self.sess)
         ro1a_id = ro1a.id
 
         group_info = {
             'display_name': 'foo group display',
-            'group_name': 'foo org',
+            'name': 'foo org',
             'root_organization_id': ro1a_id
         }
+        group = self._new_group(group_info)
         with testtools.ExpectedException(exc.BadInput):
-            api.group_create(ctx, group_info, session=self.sess)
+            api.group_create(ctx, group, session=self.sess)
 
     def test_group_create_root_not_found(self):
         ctx = mock.Mock()
         group_info = {
             'display_name': 'foo org display',
-            'group_name': 'foo org',
-            'root_organization_id': fakes.FAKE_UUID1
+            'name': 'foo org',
+            'root_organization_id': 9999
         }
+        group = self._new_group(group_info)
         with testtools.ExpectedException(exc.NotFound):
-            api.group_create(ctx, group_info, session=self.sess)
-
-    def test_group_create_invalid_root(self):
-        ctx = mock.Mock()
-        group_info = {
-            'display_name': 'foo org display',
-            'group_name': 'foo org',
-            'root_organization_id': 'notauuid'
-        }
-        with testtools.ExpectedException(exc.BadInput):
-            api.group_create(ctx, group_info, session=self.sess)
+            api.group_create(ctx, group, session=self.sess)
 
     def test_group_update_not_found(self):
         ctx = mock.Mock()
         group_info = {
             'display_name': 'foo org display',
-            'group_name': 'foo org',
+            'name': 'foo org',
             'root_organization_id': 'notauuid'
         }
         with testtools.ExpectedException(exc.NotFound):
-            api.group_update(ctx, fakes.FAKE_UUID1, group_info,
+            api.group_update(ctx, 9999, group_info,
                              session=self.sess)
 
     def test_group_update_bad_input(self):
         ctx = mock.Mock()
-        group_id = 'notauuid'
-        with testtools.ExpectedException(exc.BadInput):
-            api.group_update(ctx, group_id, {}, session=self.sess)
 
         org_info = {
             'display_name': 'root 1 display',
-            'org_name': 'root 1 org'
+            'name': 'root 1 org'
         }
-        ro1 = api.organization_create(ctx, org_info, session=self.sess)
+        org1 = self._new_org(org_info)
+        ro1 = api.organization_create(ctx, org1, session=self.sess)
         ro1_id = ro1.id
         self.addCleanup(api.organization_delete, ctx, ro1_id,
                         session=self.sess)
 
         group_info = {
             'display_name': 'group 1 display',
-            'group_name': 'group 1',
+            'name': 'group 1',
             'root_organization_id': ro1_id
         }
-        g1 = api.group_create(ctx, group_info, session=self.sess)
+        group = self._new_group(group_info)
+        g1 = api.group_create(ctx, group, session=self.sess)
         g1_id = g1.id
 
         group_info = {
             'display_name': 'group 2 display',
-            'group_name': 'group 2',
+            'name': 'group 2',
             'root_organization_id': ro1_id
         }
-        g2 = api.group_create(ctx, group_info, session=self.sess)
+        group = self._new_group(group_info)
+        g2 = api.group_create(ctx, group, session=self.sess)
         g2_id = g2.id
-
-        # Test that trying to update the group with an invalid attribute
-        # raises an error
-        update_info = {
-            'display_name': 'group 2 display',
-            'group_name': 'group 2',
-            'notavalidattr': True
-        }
-        with testtools.ExpectedException(exc.BadInput):
-            api.group_update(ctx, g1_id, update_info, session=self.sess)
 
         # Test that trying to update the group with a null root
         # organization raises an error
         update_info = {
             'display_name': 'group 1 display',
-            'group_name': 'group 1',
+            'name': 'group 1',
             'root_organization_id': None  # Required...
         }
         with testtools.ExpectedException(exc.BadInput):
@@ -398,7 +343,7 @@ class TestDbApi(base.UnitTest):
         # group within the same root organization raises an error
         update_info = {
             'display_name': 'group 2 display',
-            'group_name': 'group 1'
+            'name': 'group 1'
         }
         with testtools.ExpectedException(exc.Duplicate):
             api.group_update(ctx, g2_id, update_info, session=self.sess)
@@ -407,29 +352,32 @@ class TestDbApi(base.UnitTest):
         ctx = mock.Mock()
         org_info = {
             'display_name': 'root 1 display',
-            'org_name': 'root 1 org'
+            'name': 'root 1 org'
         }
-        ro1 = api.organization_create(ctx, org_info, session=self.sess)
+        org1 = self._new_org(org_info)
+        ro1 = api.organization_create(ctx, org1, session=self.sess)
         ro1_id = ro1.id
 
         org_info = {
             'display_name': 'root 1-a display',
-            'org_name': 'root 1-a org',
+            'name': 'root 1-a org',
             'parent_organization_id': ro1_id
         }
-        ro1a = api.organization_create(ctx, org_info, session=self.sess)
+        org1a = self._new_org(org_info)
+        ro1a = api.organization_create(ctx, org1a, session=self.sess)
         ro1a_id = ro1a.id
 
         group_info = {
             'display_name': 'root 1 group display',
-            'group_name': 'root 1 group',
+            'name': 'root 1 group',
             'root_organization_id': ro1_id
         }
-        rg1 = api.group_create(ctx, group_info, session=self.sess)
+        group = self._new_group(group_info)
+        rg1 = api.group_create(ctx, group, session=self.sess)
         self.assertIsNotNone(rg1.id)
 
         with testtools.ExpectedException(exc.Duplicate):
-            api.group_create(ctx, group_info, session=self.sess)
+            api.group_create(ctx, group, session=self.sess)
 
         self.assertEquals(rg1.display_name, group_info['display_name'])
         self.assertEquals(rg1.root_organization_id, ro1_id)
@@ -437,10 +385,11 @@ class TestDbApi(base.UnitTest):
 
         group_info = {
             'display_name': 'root 1 group 2 display',
-            'group_name': 'root 1 group 2',
+            'name': 'root 1 group 2',
             'root_organization_id': ro1_id
         }
-        rg2 = api.group_create(ctx, group_info, session=self.sess)
+        group = self._new_group(group_info)
+        rg2 = api.group_create(ctx, group, session=self.sess)
         rg2_id = rg2.id
 
         spec = fakes.get_search_spec(limit=20)
@@ -450,7 +399,7 @@ class TestDbApi(base.UnitTest):
 
         update_info = {
             'display_name': 'group 2 display',
-            'group_name': 'group 2',
+            'name': 'group 2',
             'root_organization_id': ro1_id
         }
         tmp_g2 = api.group_update(ctx, rg2_id, update_info, session=self.sess)
@@ -461,7 +410,7 @@ class TestDbApi(base.UnitTest):
         # organization also raises an error
         update_info = {
             'display_name': 'group 2 display',
-            'group_name': 'group 2',
+            'name': 'group 2',
             'root_organization_id': ro1a_id
         }
         with testtools.ExpectedException(exc.BadInput):
@@ -481,69 +430,23 @@ class TestDbApi(base.UnitTest):
     def test_group_get_by_pk_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.group_get_by_pk(ctx, fakes.FAKE_UUID1, session=self.sess)
-
-    def test_user_create_bad_data(self):
-        ctx = mock.Mock()
-        user_info = {}
-        with testtools.ExpectedException(ValueError):
-            api.user_create(ctx, user_info)
-
-    def test_user_update_bad_data(self):
-        ctx = mock.Mock()
-        user_info = {
-            'display_name': 'foo bar display',
-            'user_name': 'foo bar',
-            'email': 'foo@example.com'
-        }
-        u = api.user_create(ctx, user_info, session=self.sess)
-        self.assertIsNotNone(u.id)
-        self.addCleanup(api.user_delete, ctx, u.id, session=self.sess)
-
-        update_info = {
-            'display_name': None
-        }
-        with testtools.ExpectedException(ValueError):
-            api.user_update(ctx, u.id, update_info, session=self.sess)
-
-    def test_user_delete_bad_input(self):
-        ctx = mock.Mock()
-        user_id = 'notauuid'
-        with testtools.ExpectedException(exc.BadInput):
-            api.user_delete(ctx, user_id, session=self.sess)
-
-    def test_user_update_bad_input(self):
-        ctx = mock.Mock()
-        user_id = 'notauuid'
-        with testtools.ExpectedException(exc.BadInput):
-            api.user_update(ctx, user_id, {}, session=self.sess)
+            api.group_get_by_pk(ctx, 9999, session=self.sess)
 
     def test_user_delete_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.user_delete(ctx, fakes.FAKE_UUID1, session=self.sess)
+            api.user_delete(ctx, 9999, session=self.sess)
 
     def test_user_update_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.user_update(ctx, fakes.FAKE_UUID1, {}, session=self.sess)
-
-    def test_user_create_invalid_attr(self):
-        ctx = mock.Mock()
-        user_info = {
-            'display_name': 'foo bar display',
-            'user_name': 'foo bar',
-            'email': 'foo@example.com',
-            'notanattr': True
-        }
-        with testtools.ExpectedException(TypeError):
-            api.user_create(ctx, user_info, session=self.sess)
+            api.user_update(ctx, 9999, {}, session=self.sess)
 
     def test_user_crud(self):
         ctx = mock.Mock()
         user_info = {
             'display_name': 'foo bar display',
-            'user_name': 'foo bar',
+            'name': 'foo bar',
             'email': 'foo@example.com'
         }
         u = api.user_create(ctx, user_info, session=self.sess)
@@ -569,7 +472,7 @@ class TestDbApi(base.UnitTest):
 
         update_info = {
             'display_name': 'bar',
-            'user_name': 'fooey'
+            'name': 'fooey'
         }
         u = api.user_update(ctx, u.id, update_info, session=self.sess,
                             commit=False)
@@ -583,24 +486,17 @@ class TestDbApi(base.UnitTest):
         u = api.user_update(ctx, u.id, update_info, session=self.sess)
         self.assertFalse(self.sess.dirty)
 
-        # Test an invalid attribute set
-        update_info = {
-            'notanattr': True
-        }
-        with testtools.ExpectedException(exc.BadInput):
-            api.user_update(ctx, u.id, update_info, session=self.sess)
-
         # Try to make a user name that will produce the same slug as
         # an existing user record and verify that a Duplicate is raised
         user_info = {
             'display_name': 'baz display',
-            'user_name': 'baz',
+            'name': 'baz',
             'email': 'baz@example.com'
         }
         u2 = api.user_create(ctx, user_info, session=self.sess)
         self.addCleanup(api.user_delete, ctx, u2.id, session=self.sess)
         update_info = {
-            'user_name': 'fooey'
+            'name': 'fooey'
         }
         with testtools.ExpectedException(exc.Duplicate):
             api.user_update(ctx, u2.id, update_info, session=self.sess,
@@ -656,9 +552,10 @@ class TestDbApi(base.UnitTest):
         ctx = mock.Mock()
         org_info = {
             'display_name': 'org display',
-            'org_name': 'org'
+            'name': 'org'
         }
-        o = api.organization_create(ctx, org_info, session=self.sess)
+        org = self._new_org(org_info)
+        o = api.organization_create(ctx, org, session=self.sess)
         o_id = o.id
 
         # Not adding a cleanup, because part of this test is to ensure
@@ -668,23 +565,25 @@ class TestDbApi(base.UnitTest):
 
         group_info = {
             'display_name': 'group display',
-            'group_name': 'group',
+            'name': 'group',
             'root_organization_id': o_id
         }
-        g = api.group_create(ctx, group_info, session=self.sess)
+        group = self._new_group(group_info)
+        g = api.group_create(ctx, group, session=self.sess)
         g_id = g.id
 
         group_info = {
             'display_name': 'group 2 display',
-            'group_name': 'group 2',
+            'name': 'group 2',
             'root_organization_id': o_id
         }
-        g2 = api.group_create(ctx, group_info, session=self.sess)
+        group = self._new_group(group_info)
+        g2 = api.group_create(ctx, group, session=self.sess)
         g2_id = g2.id
 
         user_info = {
             'display_name': 'foo display',
-            'user_name': 'foo',
+            'name': 'foo',
             'email': 'foo@example.com'
         }
         u = api.user_create(ctx, user_info, session=self.sess)
@@ -700,9 +599,9 @@ class TestDbApi(base.UnitTest):
         # We should not be able to add a non-existing user to a
         # real group, nor a real user to a non-existing group.
         with testtools.ExpectedException(exc.NotFound):
-            api.user_group_add(ctx, u_id, fakes.FAKE_UUID1, session=self.sess)
+            api.user_group_add(ctx, u_id, 9999, session=self.sess)
         with testtools.ExpectedException(exc.NotFound):
-            api.user_group_add(ctx, fakes.FAKE_UUID1, g_id, session=self.sess)
+            api.user_group_add(ctx, 9999, g_id, session=self.sess)
 
         ug = api.user_group_add(ctx, u_id, g_id, session=self.sess)
         self.assertEquals(u_id, ug.user_id)
@@ -741,12 +640,12 @@ class TestDbApi(base.UnitTest):
 
         # We should not be able to remove a group from a non-existing user
         with testtools.ExpectedException(exc.NotFound):
-            api.user_group_remove(ctx, fakes.FAKE_UUID1, g_id,
+            api.user_group_remove(ctx, 9999, g_id,
                                   session=self.sess)
 
         # However, trying to remove a non-existing group from a real user
         # should simply return None.
-        api.user_group_remove(ctx, u_id, fakes.FAKE_UUID1, session=self.sess)
+        api.user_group_remove(ctx, u_id, fakes.FAKE_ID1, session=self.sess)
 
         # Deleting the organization should delete the group and any
         # associated user group membership records.
@@ -755,43 +654,27 @@ class TestDbApi(base.UnitTest):
         groups = api.user_groups_get(ctx, u_id, session=self.sess)
         self.assertThat(groups, matchers.HasLength(0))
 
-    def test_user_group_bad_data(self):
-        ctx = mock.Mock()
-        with testtools.ExpectedException(exc.BadInput):
-            api.user_group_add(ctx, 123, 456)
-        with testtools.ExpectedException(exc.BadInput):
-            api.user_group_add(ctx, fakes.FAKE_UUID1, 456)
-        ctx = mock.Mock()
-        e_patcher = mock.patch('procession.db.api._exists')
-        e_mock = e_patcher.start()
-
-        self.addCleanup(e_patcher.stop)
-
-        e_mock.return_value = True
-        with testtools.ExpectedException(exc.BadInput):
-            api.user_group_remove(ctx, fakes.FAKE_UUID1, 456)
-
     def test_user_get_by_pk_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.user_get_by_pk(ctx, fakes.FAKE_UUID1, session=self.sess)
+            api.user_get_by_pk(ctx, fakes.FAKE_ID1, session=self.sess)
 
     def test_users_get(self):
         ctx = mock.Mock()
         user_infos = [
             {
                 'display_name': 'foo display',
-                'user_name': 'foo',
+                'name': 'foo',
                 'email': 'foo@example.com'
             },
             {
                 'display_name': 'bar',
-                'user_name': 'bar',
+                'name': 'bar',
                 'email': 'bar@example.com'
             },
             {
                 'display_name': 'baz',
-                'user_name': 'baz',
+                'name': 'baz',
                 'email': 'baz@example.com'
             },
         ]
@@ -854,40 +737,25 @@ class TestDbApi(base.UnitTest):
         with testtools.ExpectedException(exc.BadInput):
             spec = fakes.get_search_spec(marker='non-existing')
             api.users_get(ctx, spec, session=self.sess)
-        with testtools.ExpectedException(exc.BadInput):
-            spec = fakes.get_search_spec(marker=fakes.FAKE_UUID1)
-            api.users_get(ctx, spec, session=self.sess)
 
     def test_user_key_get_by_pk_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.user_key_get_by_pk(ctx, fakes.FAKE_UUID1,
+            api.user_key_get_by_pk(ctx, 9999,
                                    fakes.FAKE_FINGERPRINT1, session=self.sess)
-
-    def test_user_key_create_bad_data(self):
-        ctx = mock.Mock()
-        e_patcher = mock.patch('procession.db.api._exists')
-        e_mock = e_patcher.start()
-
-        self.addCleanup(e_patcher.stop)
-
-        e_mock.return_value = True
-        user_info = {}
-        with testtools.ExpectedException(ValueError):
-            api.user_key_create(ctx, 123, user_info)
 
     def test_user_key_create_user_not_found(self):
         ctx = mock.Mock()
         key_info = {'fingerprint': '1234',
                     'public_key': 'blah'}
         with testtools.ExpectedException(exc.NotFound):
-            api.user_key_create(ctx, fakes.FAKE_UUID1, key_info)
+            api.user_key_create(ctx, fakes.FAKE_ID1, key_info)
 
     def test_user_key_delete_exceptions(self):
         ctx = mock.Mock()
         user_info = {
             'display_name': 'foo',
-            'user_name': 'foo',
+            'name': 'foo',
             'email': 'foo@example.com'
         }
         u = api.user_create(ctx, user_info, session=self.sess)
@@ -898,18 +766,15 @@ class TestDbApi(base.UnitTest):
             api.user_key_delete(ctx, u.id, fakes.FAKE_FINGERPRINT1,
                                 session=self.sess)
 
-        with testtools.ExpectedException(exc.BadInput):
-            api.user_key_delete(ctx, u.id, '1234', session=self.sess)
-
     def test_domain_get_by_pk_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.domain_get_by_pk(ctx, fakes.FAKE_UUID1, session=self.sess)
+            api.domain_get_by_pk(ctx, fakes.FAKE_ID1, session=self.sess)
 
     def test_domain_create_owner_not_found(self):
         ctx = mock.Mock()
         info = {'name': 'my domain',
-                'owner_id': fakes.FAKE_UUID1}
+                'owner_id': 9999}
         with testtools.ExpectedException(exc.NotFound):
             api.domain_create(ctx, info)
 
@@ -932,7 +797,7 @@ class TestDbApi(base.UnitTest):
         ctx = mock.Mock()
         info = {
             'name': 'foo group display',
-            'owner_id': fakes.FAKE_UUID1,
+            'owner_id': fakes.FAKE_ID1,
             'notanattr': True
         }
         with testtools.ExpectedException(TypeError):
@@ -941,16 +806,13 @@ class TestDbApi(base.UnitTest):
     def test_domain_delete_exceptions(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.domain_delete(ctx, fakes.FAKE_UUID1, session=self.sess)
-
-        with testtools.ExpectedException(exc.BadInput):
-            api.domain_delete(ctx, '1234', session=self.sess)
+            api.domain_delete(ctx, 9999, session=self.sess)
 
     def test_domain_crud(self):
         ctx = mock.Mock()
         info = {
             'display_name': 'user 1 display',
-            'user_name': 'user 1',
+            'name': 'user 1',
             'email': 'user1@example.com'
         }
         u = api.user_create(ctx, info, session=self.sess)
@@ -959,7 +821,7 @@ class TestDbApi(base.UnitTest):
 
         info = {
             'display_name': 'user 2 display',
-            'user_name': 'user 2',
+            'name': 'user 2',
             'email': 'user2@example.com'
         }
         u2 = api.user_create(ctx, info, session=self.sess)
@@ -1006,27 +868,10 @@ class TestDbApi(base.UnitTest):
         self.assertEquals(info['name'], tmp_d.name)
         self.assertEquals(u2_id, tmp_d.owner_id)
 
-        # Can't update owner_id to a non-existing user or None
-        with testtools.ExpectedException(exc.BadInput):
-            info = {
-                'owner_id': 'nonexisting'
-            }
-            api.domain_update(ctx, d2_id, info, session=self.sess)
-        with testtools.ExpectedException(exc.BadInput):
-            info = {
-                'owner_id': None
-            }
-            api.domain_update(ctx, d2_id, info, session=self.sess)
+        # Can't update owner_id to a non-existing user
         with testtools.ExpectedException(exc.NotFound):
             info = {
-                'owner_id': fakes.FAKE_UUID1
-            }
-            api.domain_update(ctx, d2_id, info, session=self.sess)
-
-        # Test an invalid attribute set
-        with testtools.ExpectedException(exc.BadInput):
-            info = {
-                'notanattr': True
+                'owner_id': 9999
             }
             api.domain_update(ctx, d2_id, info, session=self.sess)
 
@@ -1071,28 +916,22 @@ class TestDbApi(base.UnitTest):
         domains = api.domains_get(ctx, spec, session=self.sess)
         self.assertThat(domains, matchers.HasLength(1))
 
-    def test_domain_update_bad_input(self):
-        ctx = mock.Mock()
-        domain_id = 'notauuid'
-        with testtools.ExpectedException(exc.BadInput):
-            api.domain_update(ctx, domain_id, {}, session=self.sess)
-
     def test_domain_update_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.domain_update(ctx, fakes.FAKE_UUID1, {}, session=self.sess)
+            api.domain_update(ctx, 9999, {}, session=self.sess)
 
     def test_repo_get_by_pk_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.repo_get_by_pk(ctx, fakes.FAKE_UUID1, session=self.sess)
+            api.repo_get_by_pk(ctx, 9999, session=self.sess)
 
     def test_repo_create_owner_domain_not_found(self):
         ctx = mock.Mock()
 
         info = {
             'display_name': 'user 1 display',
-            'user_name': 'user 1',
+            'name': 'user 1',
             'email': 'user1@example.com'
         }
         u = api.user_create(ctx, info, session=self.sess)
@@ -1109,54 +948,26 @@ class TestDbApi(base.UnitTest):
 
         info = {'name': 'my repo',
                 'domain_id': d_id,
-                'owner_id': fakes.FAKE_UUID1}
+                'owner_id': 9999}
         with testtools.ExpectedException(exc.NotFound):
             api.repo_create(ctx, info, session=self.sess)
 
         info = {'name': 'my repo',
-                'domain_id': fakes.FAKE_UUID1,
+                'domain_id': 9999,
                 'owner_id': u_id}
         with testtools.ExpectedException(exc.NotFound):
-            api.repo_create(ctx, info, session=self.sess)
-
-    def test_repo_create_bad_data(self):
-        ctx = mock.Mock()
-        e_mock = self.patch('procession.db.api._exists')
-        e_mock.return_value = True
-        info = {}
-        with testtools.ExpectedException(ValueError):
-            api.repo_create(ctx, info)
-
-        # Missing owner ID
-        info = {
-            'name': 'my repo'
-        }
-        with testtools.ExpectedException(ValueError):
-            api.repo_create(ctx, info)
-
-    def test_repo_create_invalid_attr(self):
-        ctx = mock.Mock()
-        info = {
-            'name': 'foo group display',
-            'owner_id': fakes.FAKE_UUID1,
-            'notanattr': True
-        }
-        with testtools.ExpectedException(TypeError):
             api.repo_create(ctx, info, session=self.sess)
 
     def test_repo_delete_exceptions(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.repo_delete(ctx, fakes.FAKE_UUID1, session=self.sess)
-
-        with testtools.ExpectedException(exc.BadInput):
-            api.repo_delete(ctx, '1234', session=self.sess)
+            api.repo_delete(ctx, 9999, session=self.sess)
 
     def test_repo_crud(self):
         ctx = mock.Mock()
         info = {
             'display_name': 'user 1 display',
-            'user_name': 'user 1',
+            'name': 'user 1',
             'email': 'user1@example.com'
         }
         u = api.user_create(ctx, info, session=self.sess)
@@ -1165,7 +976,7 @@ class TestDbApi(base.UnitTest):
 
         info = {
             'display_name': 'user 2 display',
-            'user_name': 'user 2',
+            'name': 'user 2',
             'email': 'user2@example.com'
         }
         u2 = api.user_create(ctx, info, session=self.sess)
@@ -1224,43 +1035,16 @@ class TestDbApi(base.UnitTest):
         self.assertEquals(u2_id, tmp_r.owner_id)
 
         # Can't update domain_id to a non-existing user or None
-        with testtools.ExpectedException(exc.BadInput):
-            info = {
-                'domain_id': 'nonexisting'
-            }
-            api.repo_update(ctx, r2_id, info, session=self.sess)
-        with testtools.ExpectedException(exc.BadInput):
-            info = {
-                'domain_id': None
-            }
-            api.repo_update(ctx, r2_id, info, session=self.sess)
         with testtools.ExpectedException(exc.NotFound):
             info = {
-                'domain_id': fakes.FAKE_UUID1
+                'domain_id': 9999
             }
             api.repo_update(ctx, r2_id, info, session=self.sess)
 
         # Can't update owner_id to a non-existing user or None
-        with testtools.ExpectedException(exc.BadInput):
-            info = {
-                'owner_id': 'nonexisting'
-            }
-            api.repo_update(ctx, r2_id, info, session=self.sess)
-        with testtools.ExpectedException(exc.BadInput):
-            info = {
-                'owner_id': None
-            }
-            api.repo_update(ctx, r2_id, info, session=self.sess)
         with testtools.ExpectedException(exc.NotFound):
             info = {
-                'owner_id': fakes.FAKE_UUID1
-            }
-            api.repo_update(ctx, r2_id, info, session=self.sess)
-
-        # Test an invalid attribute set
-        with testtools.ExpectedException(exc.BadInput):
-            info = {
-                'notanattr': True
+                'owner_id': 9999
             }
             api.repo_update(ctx, r2_id, info, session=self.sess)
 
@@ -1348,28 +1132,22 @@ class TestDbApi(base.UnitTest):
         repos = api.repos_get(ctx, spec, session=self.sess)
         self.assertThat(repos, matchers.HasLength(0))
 
-    def test_repo_update_bad_input(self):
-        ctx = mock.Mock()
-        repo_id = 'notauuid'
-        with testtools.ExpectedException(exc.BadInput):
-            api.repo_update(ctx, repo_id, {}, session=self.sess)
-
     def test_repo_update_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.repo_update(ctx, fakes.FAKE_UUID1, {}, session=self.sess)
+            api.repo_update(ctx, 9999, {}, session=self.sess)
 
     def test_changeset_get_by_pk_not_found(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.changeset_get_by_pk(ctx, fakes.FAKE_UUID1, session=self.sess)
+            api.changeset_get_by_pk(ctx, 9999, session=self.sess)
 
     def test_changeset_create_uploaded_by_repo_not_found(self):
         ctx = mock.Mock()
 
         info = {
             'display_name': 'user 1 display',
-            'user_name': 'user 1',
+            'name': 'user 1',
             'email': 'user1@example.com'
         }
         u = api.user_create(ctx, info, session=self.sess)
@@ -1391,8 +1169,9 @@ class TestDbApi(base.UnitTest):
         }
         r = api.repo_create(ctx, info, session=self.sess)
         r_id = r.id
+        self.addCleanup(api.repo_delete, ctx, r_id, session=self.sess)
 
-        info = {'target_repo_id': fakes.FAKE_UUID1,
+        info = {'target_repo_id': 9999,
                 'target_branch': 'blah',
                 'uploaded_by': u_id,
                 'commit_message': ''}
@@ -1401,7 +1180,7 @@ class TestDbApi(base.UnitTest):
 
         info = {'target_repo_id': r_id,
                 'target_branch': 'blah',
-                'uploaded_by': fakes.FAKE_UUID1,
+                'uploaded_by': 9999,
                 'commit_message': ''}
         with testtools.ExpectedException(exc.NotFound):
             api.changeset_create(ctx, info, session=self.sess)
@@ -1450,30 +1229,16 @@ class TestDbApi(base.UnitTest):
         with testtools.ExpectedException(ValueError):
             api.changeset_create(ctx, info)
 
-    def test_changeset_create_invalid_attr(self):
-        ctx = mock.Mock()
-        info = {
-            'target_repo_id': 'blah',
-            'target_branch': 'blah',
-            'uploaded_by': 'blah',
-            'notanattr': True
-        }
-        with testtools.ExpectedException(TypeError):
-            api.changeset_create(ctx, info, session=self.sess)
-
     def test_changeset_delete_exceptions(self):
         ctx = mock.Mock()
         with testtools.ExpectedException(exc.NotFound):
-            api.changeset_delete(ctx, fakes.FAKE_UUID1, session=self.sess)
-
-        with testtools.ExpectedException(exc.BadInput):
-            api.changeset_delete(ctx, '1234', session=self.sess)
+            api.changeset_delete(ctx, 9999, session=self.sess)
 
     def test_changeset_crud(self):
         ctx = mock.Mock()
         info = {
             'display_name': 'user 1 display',
-            'user_name': 'user 1',
+            'name': 'user 1',
             'email': 'user1@example.com'
         }
         u = api.user_create(ctx, info, session=self.sess)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -56,6 +56,8 @@ def _user_to_dict(self):
     }
 
 
+FAKE_ID1 = 1
+FAKE_ID2 = 2
 FAKE_UUID1 = 'c52007d5-dbca-4897-a86a-51e800753dec'
 FAKE_UUID2 = '1c552546-73a6-445b-83e8-c07e1b5eaf10'
 FAKE_FINGERPRINT1 = '43:51:43:a1:b5:fc:8b:b7:0a:3a:a9:b1:0f:66:73:a8'
@@ -63,12 +65,12 @@ FAKE_FINGERPRINT2 = '8a:37:66:f0:1b:9a:a3:a0:7b:b8:cf:5b:1a:34:15:34'
 
 _m = mock.MagicMock()
 _m.__class__ = models.Organization
-_m.id = FAKE_UUID1
+_m.id = FAKE_ID1
 _m.display_name = 'Jets'
 _m.org_name = 'jets'
 _m.slug = 'sharks'
 _m.parent_organization_id = None
-_m.root_organization_id = FAKE_UUID1
+_m.root_organization_id = FAKE_ID1
 _m.created_on = str(datetime.datetime(2013, 4, 27, 2, 45, 2))
 _m.to_dict.return_value = _org_to_dict(_m)
 
@@ -76,12 +78,12 @@ FAKE_ORG1 = _m
 
 _m = mock.MagicMock()
 _m.__class__ = models.Organization
-_m.id = FAKE_UUID2
+_m.id = FAKE_ID2
 _m.display_name = 'Sharks'
 _m.org_name = 'sharks'
 _m.slug = 'sharks'
 _m.parent_organization_id = None
-_m.root_organization_id = FAKE_UUID2
+_m.root_organization_id = FAKE_ID2
 _m.created_on = str(datetime.datetime(2013, 4, 27, 2, 45, 2))
 _m.to_dict.return_value = _org_to_dict(_m)
 
@@ -94,7 +96,7 @@ FAKE_ORGS = [
 
 _m = mock.MagicMock()
 _m.__class__ = models.User
-_m.id = FAKE_UUID1
+_m.id = FAKE_ID1
 _m.display_name = 'Albert Einstein'
 _m.user_name = 'albert'
 _m.slug = 'albert-einstein'
@@ -108,7 +110,7 @@ FAKE_USER1_YAML = yaml.dump(_user_to_dict(_m))
 
 _m = mock.MagicMock()
 _m.__class__ = models.User
-_m.id = FAKE_UUID2
+_m.id = FAKE_ID2
 _m.display_name = 'Charles Darwin'
 _m.user_name = 'chuck'
 _m.slug = 'charles-darwin'
@@ -129,7 +131,7 @@ FAKE_USERS_JSON = json.dumps([_user_to_dict(u) for u in FAKE_USERS])
 
 _m = mock.MagicMock()
 _m.__class__ = models.UserPublicKey
-_m.user_id = FAKE_UUID1
+_m.user_id = FAKE_ID1
 _m.fingerprint = FAKE_FINGERPRINT1
 _m.public_key = 'publickey1'
 _m.created_on = str(datetime.datetime(2013, 3, 11, 2, 23, 10))
@@ -139,7 +141,7 @@ FAKE_KEY1 = _m
 
 _m = mock.MagicMock()
 _m.__class__ = models.UserPublicKey
-_m.user_id = FAKE_UUID2
+_m.user_id = FAKE_ID2
 _m.fingerprint = FAKE_FINGERPRINT2
 _m.public_key = 'publickey2'
 _m.created_on = str(datetime.datetime(2013, 3, 11, 2, 23, 10))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -15,6 +15,9 @@
 # under the License.
 
 import uuid
+import yaml.parser
+
+import testtools
 
 from procession import helpers
 
@@ -22,7 +25,7 @@ from tests import fakes
 from tests import base
 
 
-class TestHelpers(base.UnitTest):
+class TestIsLikeUuid(base.UnitTest):
 
     def test_is_like_uuid(self):
         bad_subjects = [
@@ -46,3 +49,16 @@ class TestHelpers(base.UnitTest):
         # Ensure passing an actual UUID object returns True
         subject = uuid.uuid4()
         self.assertTrue(helpers.is_like_uuid(subject))
+
+
+class TestSerializers(base.UnitTest):
+
+    def test_deserialize_bad_json(self):
+        with testtools.ExpectedException(ValueError):
+            blob = "{asl12^ak"
+            helpers.deserialize_json(blob)
+
+    def test_deserialize_bad_yaml(self):
+        with testtools.ExpectedException(yaml.parser.ParserError):
+            blob = "{asl12^ak"
+            helpers.deserialize_yaml(blob)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -16,9 +16,8 @@
 
 import jsonschema
 import testtools
-from testtools import matchers
 
-from procession.api import objects
+from procession import objects
 
 from tests import base
 
@@ -45,7 +44,7 @@ TEST_SCHEMA = {
 }
 
 
-class TestApiObjects(base.UnitTest):
+class TestObjects(base.UnitTest):
 
     def test_object_base(self):
 
@@ -58,14 +57,14 @@ class TestApiObjects(base.UnitTest):
             'age': -1  # Must be greater than or equal to zero
         }
         with testtools.ExpectedException(jsonschema.ValidationError):
-            MyObject(instance)
+            MyObject.from_py_object(instance)
 
         instance = {
             'first_name': 'Albert',
             'last_name': 'Einstein',
             'age': 73
         }
-        obj = MyObject(instance)
+        obj = MyObject.from_py_object(instance)
         with testtools.ExpectedException(jsonschema.ValidationError):
             obj.age = -1
         # Test that the above setter was replaced by the original
@@ -74,4 +73,13 @@ class TestApiObjects(base.UnitTest):
 
         # Test __getattr__ translation of KeyError to AttributeError
         with testtools.ExpectedException(AttributeError):
-            _ignored = obj.nonexistattr
+            obj.nonexistattr
+
+        # Try creating an instance of the object without one of the
+        # optional fields.
+        instance = {
+            'first_name': 'Albert',
+            'last_name': 'Einstein'
+        }
+        obj = MyObject.from_py_object(instance)
+        self.assertIsNone(obj.age)


### PR DESCRIPTION
Changes create methods in DB API for organization and group to use
objects -- which have validation built in to them. In the process, we
changed from UUID identifiers to integer identifiers, for scale and
performance reasons, as well as human-readability.

Moves objects out of procession/api/ and into the main procession/
namespace, and moves some of the serialization base routines out of the
api helpers and into the main procession helpers.
