### PR TITLE
Fixes #19: show >1 level of org treeview

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -197,8 +197,13 @@ command to see a tree-view of the organizations matching any filters:
 
 ```
 $ p7n organization list --tree
-Cartoons (10b4e38038c911e7940fe06995034837)
--> The Flintstones (3f09849ba1724eac9e77687495dab9f4)
+── A (d282791a50444b069c6ff7f0e8781211)
+   └── C (f1f1584b641042c19de9e333feabeaa4)
+       └── C.2 (7cee11944528412991dd785dde90fcab)
+       └── C.1 (5558861719ca43d4978427826f0a4404)
+           └── C.1.a (82ba2cc190b541b4928ec7128d4f893e)
+       └── C.3 (ea61661cc4ae4a51b9b8c95967ead432)
+   └── B (f72370fe01cd43f89c1ffd54a2b83295)
 ```
 
 To delete an organization, use the `p7n organization delete <organization>`

--- a/p7n/commands/organization_set.go
+++ b/p7n/commands/organization_set.go
@@ -81,7 +81,7 @@ func orgSet(cmd *cobra.Command, args []string) error {
     fmt.Printf("Display name: %s\n", org.DisplayName)
     fmt.Printf("Slug:         %s\n", org.Slug)
     if org.ParentUuid != nil {
-        fmt.Printf("Parent:         %s\n", org.ParentUuid.Value)
+        fmt.Printf("Parent:       %s\n", org.ParentUuid.Value)
     }
     return nil
 }


### PR DESCRIPTION
This patch fixes Issue #19 by properly adding >1 level of nesting to the output
of `p7n organization list --tree`. We use a map of string -> []*orgTreeNode to
do a single pass through the returned list of organizations and look up a
parent org tree node if it has yet to be created by the time we hit on a node
that has it as its parent.