### PR TITLE
authz: add role DB schema and role get fn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test: test-unit test-e2e
 
 test-unit: build
 	@echo "Running unit tests ... "
-	@go test ./...
+	@go test `go list ./... | grep -v vendor`
 
 test-e2e: build
 	@echo "Running end-to-end tests ... "

--- a/migrate/iam/20170514130700_add_organizations.sql
+++ b/migrate/iam/20170514130700_add_organizations.sql
@@ -1,4 +1,3 @@
-
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
 

--- a/migrate/iam/20170626165743_authz.sql
+++ b/migrate/iam/20170626165743_authz.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+CREATE TABLE IF NOT EXISTS roles (
+  id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY
+, uuid CHAR(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL
+, root_organization_id INT UNSIGNED NULL
+, display_name VARCHAR(100) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL
+, slug VARCHAR(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL
+, generation INT NOT NULL
+, UNIQUE INDEX uix_uuid (uuid)
+, UNIQUE INDEX uix_root_organization_id_display_name (root_organization_id, display_name)
+, UNIQUE INDEX uix_slug_root_organization_id (slug, root_organization_id)
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+  id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY
+, role_id INT UNSIGNED NOT NULL
+, permission INT UNSIGNED NOT NULL
+, UNIQUE INDEX uix_role_id_permission (role_id, permission)
+);
+
+CREATE TABLE IF NOT EXISTS user_roles (
+  id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY
+, user_id INT UNSIGNED NOT NULL
+, role_id INT UNSIGNED NOT NULL
+, UNIQUE INDEX uix_user_id_role_id (user_id, role_id)
+);
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back

--- a/pkg/iam/db/role.go
+++ b/pkg/iam/db/role.go
@@ -1,0 +1,121 @@
+package db
+
+import (
+    "database/sql"
+    "log"
+
+    "github.com/jaypipes/procession/pkg/context"
+    "github.com/jaypipes/procession/pkg/util"
+    pb "github.com/jaypipes/procession/proto"
+)
+
+// Returns a pb.Role message filled with information about a requested role
+func RoleGet(
+    ctx *context.Context,
+    search string,
+) (*pb.Role, error) {
+    reset := ctx.LogSection("iam/db")
+    defer reset()
+    db := ctx.Db
+    qargs := make([]interface{}, 0)
+    qs := `
+SELECT
+  r.id
+, r.uuid
+, r.display_name
+, r.slug
+, r.generation
+, o.uuid as organization_uuid
+FROM roles AS r
+LEFT JOIN organizations AS o
+  ON r.root_organization_id = o.id
+WHERE `
+    if util.IsUuidLike(search) {
+        qs = qs + "r.uuid = ?"
+        qargs = append(qargs, util.UuidFormatDb(search))
+    } else {
+        qs = qs + "r.display_name = ? OR r.slug = ?"
+        qargs = append(qargs, search)
+        qargs = append(qargs, search)
+    }
+
+    ctx.LSQL(qs)
+
+    rows, err := db.Query(qs, qargs...)
+    if err != nil {
+        return nil, err
+    }
+    err = rows.Err()
+    if err != nil {
+        return nil, err
+    }
+    defer rows.Close()
+
+    var roleId int64
+    role := pb.Role{}
+    for rows.Next() {
+        var orgUuid sql.NullString
+        err = rows.Scan(
+            &roleId,
+            &role.Uuid,
+            &role.DisplayName,
+            &role.Slug,
+            &role.Generation,
+            &orgUuid,
+        )
+        if err != nil {
+            return nil, err
+        }
+        if orgUuid.Valid {
+            sv := &pb.StringValue{Value: orgUuid.String}
+            role.OrganizationUuid = sv
+        }
+        break
+    }
+
+    perms, err := RolePermissionsGetById(ctx, roleId)
+    if err != nil {
+        return nil, err
+    }
+    role.Permissions = perms
+    return &role, nil
+}
+
+// Given a pb.Role message, populates the list of permissions for a specified role ID
+func RolePermissionsGetById(
+    ctx *context.Context,
+    roleId int64,
+) ([]pb.Permission, error) {
+    reset := ctx.LogSection("iam/db")
+    defer reset()
+    db := ctx.Db
+    qs := `
+SELECT
+  rp.permission
+FROM role_permissions AS rp
+WHERE rp.role_id = ?
+`
+    ctx.LSQL(qs)
+
+    rows, err := db.Query(qs, roleId)
+    if err != nil {
+        log.Fatal(err)
+    }
+    err = rows.Err()
+    if err != nil {
+        return nil, err
+    }
+
+    perms := make([]pb.Permission, 0)
+    for rows.Next() {
+        var perm int64
+        err = rows.Scan(
+            &perm,
+        )
+        if err != nil {
+            return nil, err
+        }
+        perms = append(perms, pb.Permission(perm))
+    }
+    return perms, nil
+}

--- a/pkg/iam/server/role.go
+++ b/pkg/iam/server/role.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+    "golang.org/x/net/context"
+
+    pb "github.com/jaypipes/procession/proto"
+
+    "github.com/jaypipes/procession/pkg/iam/db"
+)
+
+// RoleGet looks up a organization record by organization identifier
+// and returns the Role protobuf message for the organization
+func (s *Server) RoleGet(
+    ctx context.Context,
+    req *pb.RoleGetRequest,
+) (*pb.Role, error) {
+    reset := s.Ctx.LogSection("iam/server")
+    defer reset()
+
+    s.Ctx.L3("Getting role %s", req.Search)
+
+    role, err := db.RoleGet(s.Ctx, req.Search)
+    if err != nil {
+        return nil, err
+    }
+    return role, nil
+}

--- a/pkg/iam/server/server.go
+++ b/pkg/iam/server/server.go
@@ -41,7 +41,7 @@ func New(ctx *context.Context) (*Server, error) {
         return nil, fmt.Errorf("failed to instantiate authz: %v", err)
     }
     ctx.Authz = authz
-    ctx.L2("connected to DB.")
+    ctx.L2("auth system initialized.")
 
     s := &Server{
         Ctx: ctx,

--- a/proto/defs/authz.proto
+++ b/proto/defs/authz.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package procession;
 
+import "session.proto";
+import "wrappers.proto";
+
 // Global types of permissions for Procession
 enum Permission {
     SUPER = 0;
@@ -73,4 +76,43 @@ message Permissions {
     // A map, keyed by the scope (typically the organization UUID), containing
     // permissions for a user against that particular scope
     map<string, ScopedPermissions> scoped_permissions = 2;
+}
+
+// A role is a set of permissions that may be applied to a user, globally
+message Role {
+    string uuid = 1;
+    string display_name = 2;
+    string slug = 3;
+    StringValue organization_uuid = 4;
+    repeated Permission permissions = 5;
+    uint32 generation = 100;
+}
+
+message RoleGetRequest {
+    Session session = 1;
+    string search = 2;
+}
+
+message RoleSetFields {
+    StringValue display_name = 1;
+    StringValue organization_uuid = 2;
+    repeated Permission add = 3;
+    repeated Permission remove = 4;
+}
+
+message RoleSetRequest {
+    Session session = 1;
+    StringValue search = 2;
+    RoleSetFields changed = 3;
+}
+
+message RoleSetResponse {
+    Role role = 1;
+}
+
+message RoleListFilters {
+    StringValue organization = 1;
+    repeated string uuids = 2;
+    repeated string display_names = 3;
+    repeated string slugs = 4;
 }

--- a/proto/defs/service_iam.proto
+++ b/proto/defs/service_iam.proto
@@ -2,12 +2,16 @@ syntax = "proto3";
 
 package procession;
 
+import "authz.proto";
 import "organization.proto";
 import "user.proto";
 
 // The IAM gRPC service handles storage and operations for users,
 // organizations, authorization, etc.
 service IAM {
+    // Returns information about a specific role
+    rpc role_get(RoleGetRequest) returns (Role) {}
+
     // Returns information about a specific user
     rpc user_get(UserGetRequest) returns (User) {}
 


### PR DESCRIPTION
Begins the process of adding in the role and role-permission storage. A new set
of tables in the IAM DB schema is added and the initial role_get IAM service
API RPC method is implemented.

Regardless of whether we rework the authz module to use Casbin after @hsluoyz's
excellent feedback and suggestions for how to do the type of policy enforcement
we need, we will still need a strategy for storing the permissions information
and role information in backend storage. Since we plan to use gRPC and
protobuffers for our API and data modeling, this step is essential even if we
go with Casbin.

Issue #11