### PR TITLE
p7n: Add role get command

### DIFF
--- a/p7n/commands/role.go
+++ b/p7n/commands/role.go
@@ -1,0 +1,14 @@
+package commands
+
+import (
+    "github.com/spf13/cobra"
+)
+
+var roleCommand = &cobra.Command{
+    Use: "role",
+    Short: "Manipulate role information",
+}
+
+func init() {
+    roleCommand.AddCommand(roleGetCommand)
+}

--- a/p7n/commands/role_get.go
+++ b/p7n/commands/role_get.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+    "fmt"
+    "strings"
+    "golang.org/x/net/context"
+
+    "github.com/spf13/cobra"
+    pb "github.com/jaypipes/procession/proto"
+)
+
+var roleGetCommand = &cobra.Command{
+    Use: "get <search>",
+    Short: "Get information for a single role",
+    RunE: roleGet,
+}
+
+func roleGet(cmd *cobra.Command, args []string) error {
+    checkAuthUser(cmd)
+    if len(args) == 0 {
+        fmt.Println("Please specify a UUID, name or slug to search for.")
+        cmd.Usage()
+        return nil
+    }
+    conn := connect()
+    defer conn.Close()
+
+    client := pb.NewIAMClient(conn)
+    req := &pb.RoleGetRequest{
+        Session: &pb.Session{User: authUser},
+        Search: args[0],
+    }
+    role, err := client.RoleGet(context.Background(), req)
+    if err != nil {
+        return err
+    }
+    if role.Uuid == "" {
+        fmt.Printf("No role found matching request\n")
+        return nil
+    }
+    fmt.Printf("UUID:         %s\n", role.Uuid)
+    if role.OrganizationUuid != nil {
+        orgUuid := role.OrganizationUuid.Value
+        fmt.Printf("Organization: %s\n", orgUuid)
+    }
+    fmt.Printf("Display name: %s\n", role.DisplayName)
+    fmt.Printf("Slug:         %s\n", role.Slug)
+    if len(role.Permissions) > 0 {
+        strPerms := make([]string, len(role.Permissions))
+        for x, perm := range role.Permissions {
+            strPerms[x] = perm.String()
+        }
+        permStr := strings.Join(strPerms, ", ")
+        fmt.Printf("Permissions:  %s\n", permStr)
+    } else {
+        fmt.Printf("Permissions:  None\n")
+    }
+    return nil
+}

--- a/p7n/commands/root.go
+++ b/p7n/commands/root.go
@@ -107,6 +107,7 @@ func init() {
 
     RootCommand.AddCommand(userCommand)
     RootCommand.AddCommand(orgCommand)
+    RootCommand.AddCommand(roleCommand)
     RootCommand.AddCommand(meCommand)
     RootCommand.AddCommand(helpEnvCommand)
     RootCommand.SilenceUsage = true

--- a/pkg/iam/db/role.go
+++ b/pkg/iam/db/role.go
@@ -96,6 +96,7 @@ FROM role_permissions AS rp
 WHERE rp.role_id = ?
 `
     ctx.LSQL(qs)
+    ctx.L1("Getting permissions for role ID %d", roleId)
 
     rows, err := db.Query(qs, roleId)
     if err != nil {
@@ -113,6 +114,7 @@ WHERE rp.role_id = ?
             &perm,
         )
         if err != nil {
+            ctx.LERR("Error scanning permissions: %v", err)
             return nil, err
         }
         perms = append(perms, pb.Permission(perm))


### PR DESCRIPTION
Implements the `p7n role get <search>` command for outputting
information about a role.

Issue #11