### PR TITLE
authz: remove ScopedPermission enum type

### DIFF
--- a/p7n/commands/role_get.go
+++ b/p7n/commands/role_get.go
@@ -45,9 +45,9 @@ func roleGet(cmd *cobra.Command, args []string) error {
     }
     fmt.Printf("Display name: %s\n", role.DisplayName)
     fmt.Printf("Slug:         %s\n", role.Slug)
-    if len(role.Permissions) > 0 {
-        strPerms := make([]string, len(role.Permissions))
-        for x, perm := range role.Permissions {
+    if role.PermissionSet != nil && len(role.PermissionSet.Permissions) > 0 {
+        strPerms := make([]string, len(role.PermissionSet.Permissions))
+        for x, perm := range role.PermissionSet.Permissions {
             strPerms[x] = perm.String()
         }
         permStr := strings.Join(strPerms, ", ")

--- a/pkg/authz/authz.go
+++ b/pkg/authz/authz.go
@@ -44,7 +44,7 @@ func (a *Authz) Check(
     if sessPerms == nil {
         return false
     }
-    perms := sessPerms.Permissions
+    perms := sessPerms.System.Permissions
     find := []pb.Permission{
         pb.Permission_SUPER,  // SUPER permission is allowed to do anything...
         checked,

--- a/pkg/authz/cache.go
+++ b/pkg/authz/cache.go
@@ -44,7 +44,9 @@ func (pc *PermissionsCache) find(user string) *cacheEntry {
 func (pc *PermissionsCache) load(user string) *cacheEntry {
     // TODO(jaypipes): Load from DB or other storage
     perms := &pb.Permissions{
-        Permissions: []pb.Permission{},
+        System: &pb.PermissionSet{
+            Permissions: []pb.Permission{},
+        },
     }
     expires := time.Now().Add(time.Duration(15 * time.Minute))
     entry := &cacheEntry{

--- a/pkg/iam/db/role.go
+++ b/pkg/iam/db/role.go
@@ -77,7 +77,9 @@ WHERE `
     if err != nil {
         return nil, err
     }
-    role.Permissions = perms
+    role.PermissionSet = &pb.PermissionSet{
+        Permissions: perms,
+    }
     return &role, nil
 }
 
@@ -96,7 +98,6 @@ FROM role_permissions AS rp
 WHERE rp.role_id = ?
 `
     ctx.LSQL(qs)
-    ctx.L1("Getting permissions for role ID %d", roleId)
 
     rows, err := db.Query(qs, roleId)
     if err != nil {
@@ -114,7 +115,6 @@ WHERE rp.role_id = ?
             &perm,
         )
         if err != nil {
-            ctx.LERR("Error scanning permissions: %v", err)
             return nil, err
         }
         perms = append(perms, pb.Permission(perm))

--- a/proto/defs/authz.proto
+++ b/proto/defs/authz.proto
@@ -35,47 +35,17 @@ enum Permission {
     END_PERMS = 999999;
 }
 
-// Permissions for actions when operating within an organization
-enum ScopedPermission {
-    SCOPED_SUPER = 0;
-    SCOPED_READ_ANY = 1;
-    SCOPED_READ_ORGANIZATION = 2;
-    SCOPED_READ_USER = 3;
-    SCOPED_READ_REPO = 4;
-    SCOPED_READ_CHANGESET = 5;
-    SCOPED_READ_CHANGE = 6;
-    SCOPED_CREATE_ANY = 101;
-    SCOPED_CREATE_ORGANIZATION = 102;
-    SCOPED_CREATE_USER = 103;
-    SCOPED_CREATE_REPO = 104;
-    SCOPED_CREATE_CHANGESET = 105;
-    SCOPED_CREATE_CHANGE = 106;
-    SCOPED_MODIFY_ANY = 201;
-    SCOPED_MODIFY_ORGANIZATION = 202;
-    SCOPED_MODIFY_USER = 203;
-    SCOPED_MODIFY_REPO = 204;
-    SCOPED_MODIFY_CHANGESET = 205;
-    SCOPED_MODIFY_CHANGE = 206;
-    SCOPED_DELETE_ANY = 301;
-    SCOPED_DELETE_ORGANIZATION = 302;
-    SCOPED_DELETE_USER = 303;
-    SCOPED_DELETE_REPO = 304;
-    SCOPED_DELETE_CHANGESET = 305;
-    SCOPED_DELETE_CHANGE = 306;
-    SCOPED_END_PERMS = 999999;
-}
-
-// The set of permissions that a user can have on an organization
-message ScopedPermissions {
-    repeated ScopedPermission permissions = 1;
+message PermissionSet {
+    repeated Permission permissions = 1;
 }
 
 // The set of system and object permissions that a user has during a session
 message Permissions {
-    repeated Permission permissions = 1;
+    // Globally-applicable permissions
+    PermissionSet system = 1;
     // A map, keyed by the scope (typically the organization UUID), containing
     // permissions for a user against that particular scope
-    map<string, ScopedPermissions> scoped_permissions = 2;
+    map<string, PermissionSet> scoped = 2;
 }
 
 // A role is a set of permissions that may be applied to a user, globally
@@ -84,7 +54,7 @@ message Role {
     string display_name = 2;
     string slug = 3;
     StringValue organization_uuid = 4;
-    repeated Permission permissions = 5;
+    PermissionSet permission_set = 5;
     uint32 generation = 100;
 }
 
@@ -96,8 +66,8 @@ message RoleGetRequest {
 message RoleSetFields {
     StringValue display_name = 1;
     StringValue organization_uuid = 2;
-    repeated Permission add = 3;
-    repeated Permission remove = 4;
+    PermissionSet add = 3;
+    PermissionSet remove = 4;
 }
 
 message RoleSetRequest {


### PR DESCRIPTION
Permissions are not scoped. Rather, the things to which a permission is
applied may be scoped. In this patch, we remove the duplicative
ScopedPermission enum and change the Permissions message to contain a
PermissionSet message and a map of string to PermissionSet messages,
one for system permissions the other for permissions scoped to a
particular organization.

Issue #11