### PR TITLE
authz: create and update roles

### DIFF
--- a/p7n/commands/organization_update.go
+++ b/p7n/commands/organization_update.go
@@ -73,7 +73,7 @@ func orgUpdate(cmd *cobra.Command, args []string) error {
         return err
     }
     org := resp.Organization
-    fmt.Printf("Successfully saved organation %s\n", org.Uuid)
+    fmt.Printf("Successfully saved organization %s\n", org.Uuid)
     fmt.Printf("UUID:         %s\n", org.Uuid)
     fmt.Printf("Display name: %s\n", org.DisplayName)
     fmt.Printf("Slug:         %s\n", org.Slug)

--- a/p7n/commands/role.go
+++ b/p7n/commands/role.go
@@ -11,4 +11,6 @@ var roleCommand = &cobra.Command{
 
 func init() {
     roleCommand.AddCommand(roleGetCommand)
+    roleCommand.AddCommand(roleCreateCommand)
+    roleCommand.AddCommand(roleUpdateCommand)
 }

--- a/p7n/commands/role_create.go
+++ b/p7n/commands/role_create.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+    "fmt"
+    "os"
+    "golang.org/x/net/context"
+
+    "github.com/spf13/cobra"
+    pb "github.com/jaypipes/procession/proto"
+)
+
+var (
+    roleCreateDisplayName string
+    roleCreateOrganizationUuid string
+)
+
+var roleCreateCommand = &cobra.Command{
+    Use: "create",
+    Short: "Creates a new role",
+    RunE: roleCreate,
+}
+
+func setupRoleCreateFlags() {
+    roleCreateCommand.Flags().StringVarP(
+        &roleCreateDisplayName,
+        "display-name", "n",
+        "",
+        "Display name for the role.",
+    )
+    roleCreateCommand.Flags().StringVarP(
+        &roleCreateOrganizationUuid,
+        "organization-uuid", "",
+        "",
+        "UUID of the organization that the role should be scoped to, if any.",
+    )
+}
+
+func init() {
+    setupRoleCreateFlags()
+}
+
+func roleCreate(cmd *cobra.Command, args []string) error {
+    checkAuthUser(cmd)
+    conn := connect()
+    defer conn.Close()
+
+    client := pb.NewIAMClient(conn)
+    req := &pb.RoleSetRequest{
+        Session: &pb.Session{User: authUser},
+        Changed: &pb.RoleSetFields{},
+    }
+
+    if cmd.Flags().Changed("display-name") {
+        req.Changed.DisplayName = &pb.StringValue{
+            Value: roleCreateDisplayName,
+        }
+    } else {
+        fmt.Println("Specify a display name using --display-name=<NAME>.")
+        cmd.Usage()
+        os.Exit(1)
+    }
+    if cmd.Flags().Changed("organization-uuid") {
+        req.Changed.OrganizationUuid = &pb.StringValue{
+            Value: roleCreateOrganizationUuid,
+        }
+    }
+    resp, err := client.RoleSet(context.Background(), req)
+    if err != nil {
+        return err
+    }
+    role := resp.Role
+    if quiet {
+        fmt.Println(role.Uuid)
+    } else {
+        fmt.Printf("Successfully created role with UUID %s\n", role.Uuid)
+        fmt.Printf("UUID:         %s\n", role.Uuid)
+        if role.OrganizationUuid != nil {
+            fmt.Printf("Organization: %s\n", role.OrganizationUuid.Value)
+        }
+        fmt.Printf("Display name: %s\n", role.DisplayName)
+        fmt.Printf("Slug:         %s\n", role.Slug)
+    }
+    return nil
+}
+

--- a/p7n/commands/role_update.go
+++ b/p7n/commands/role_update.go
@@ -1,0 +1,87 @@
+package commands
+
+import (
+    "fmt"
+    "os"
+    "golang.org/x/net/context"
+
+    "github.com/spf13/cobra"
+    pb "github.com/jaypipes/procession/proto"
+)
+
+var (
+    roleUpdateDisplayName string
+    roleUpdateOrganizationUuid string
+)
+
+var roleUpdateCommand = &cobra.Command{
+    Use: "update <identifier>",
+    Short: "Updates information for an role",
+    RunE: roleUpdate,
+}
+
+func setupRoleUpdateFlags() {
+    roleUpdateCommand.Flags().StringVarP(
+        &roleUpdateDisplayName,
+        "display-name", "n",
+        "",
+        "Display name for the role.",
+    )
+    roleUpdateCommand.Flags().StringVarP(
+        &roleUpdateOrganizationUuid,
+        "organization-uuid", "o",
+        "",
+        "UUID of the organization the role should be scoped to, if any.",
+    )
+}
+
+func init() {
+    setupRoleUpdateFlags()
+}
+
+func roleUpdate(cmd *cobra.Command, args []string) error {
+    checkAuthUser(cmd)
+    conn := connect()
+    defer conn.Close()
+
+    client := pb.NewIAMClient(conn)
+    req := &pb.RoleSetRequest{
+        Session: &pb.Session{User: authUser},
+        Changed: &pb.RoleSetFields{},
+    }
+
+    if len(args) != 1 {
+        fmt.Println("Please specify an role identifier.")
+        cmd.Usage()
+        os.Exit(1)
+    } else {
+        req.Search = &pb.StringValue{Value: args[0]}
+    }
+
+    if cmd.Flags().Changed("display-name") {
+        req.Changed.DisplayName = &pb.StringValue{
+            Value: roleUpdateDisplayName,
+        }
+    }
+    if cmd.Flags().Changed("organization-uuid") {
+        req.Changed.OrganizationUuid = &pb.StringValue{
+            Value: roleUpdateOrganizationUuid,
+        }
+    }
+    resp, err := client.RoleSet(context.Background(), req)
+    if err != nil {
+        return err
+    }
+    if ! quiet {
+        role := resp.Role
+        fmt.Printf("Successfully saved role %s\n", role.Uuid)
+        fmt.Printf("UUID:         %s\n", role.Uuid)
+        if role.OrganizationUuid != nil {
+            fmt.Printf("Organization:       %s\n", role.OrganizationUuid.Value)
+        }
+        fmt.Printf("Display name: %s\n", role.DisplayName)
+        fmt.Printf("Slug:         %s\n", role.Slug)
+    }
+    return nil
+}
+

--- a/pkg/iam/db/role.go
+++ b/pkg/iam/db/role.go
@@ -239,6 +239,8 @@ func RoleUpdate(
         newRole.DisplayName = before.DisplayName
         newRole.Slug = before.Slug
     }
+    // Increment the generation
+    changes["generation"] = before.Generation + 1
     for field, _ := range changes {
         qs = qs + fmt.Sprintf("%s = ?, ", field)
     }

--- a/pkg/iam/db/role.go
+++ b/pkg/iam/db/role.go
@@ -2,7 +2,12 @@ package db
 
 import (
     "database/sql"
+    "fmt"
     "log"
+    "strings"
+
+    "github.com/gosimple/slug"
+    "github.com/go-sql-driver/mysql"
 
     "github.com/jaypipes/procession/pkg/context"
     "github.com/jaypipes/procession/pkg/util"
@@ -120,4 +125,156 @@ WHERE rp.role_id = ?
         perms = append(perms, pb.Permission(perm))
     }
     return perms, nil
+}
+
+// Creates a new record for an role
+func RoleCreate(
+    sess *pb.Session,
+    ctx *context.Context,
+    fields *pb.RoleSetFields,
+) (*pb.Role, error) {
+    reset := ctx.LogSection("iam/db")
+    defer reset()
+    db := ctx.Db
+    tx, err := db.Begin()
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer tx.Rollback()
+
+    uuid := util.Uuid4Char32()
+    displayName := fields.DisplayName.Value
+    slug := slug.Make(displayName)
+    var rootOrgId interface{}
+    if fields.OrganizationUuid != nil {
+        rootOrgUuid := fields.OrganizationUuid.Value
+        rootOrgInternalId := orgIdFromIdentifier(ctx, rootOrgUuid)
+        if rootOrgInternalId == 0 {
+            err = fmt.Errorf("No such organization %s", rootOrgUuid)
+            return nil, err
+        }
+        rootOrgId = rootOrgInternalId
+    }
+
+    qs := `
+INSERT INTO roles (
+  uuid
+, display_name
+, slug
+, root_organization_id
+, generation
+) VALUES (?, ?, ?, ?, ?)
+`
+
+    ctx.LSQL(qs)
+
+    stmt, err := tx.Prepare(qs)
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer stmt.Close()
+    _, err = stmt.Exec(
+        uuid,
+        displayName,
+        slug,
+        rootOrgId,
+        1,
+    )
+    if err != nil {
+        me, ok := err.(*mysql.MySQLError)
+        if !ok {
+            return nil, err
+        }
+        if me.Number == 1062 {
+            // Duplicate key, check if it's the slug...
+            if strings.Contains(me.Error(), "uix_slug_root_organization_id") {
+                return nil, fmt.Errorf("Duplicate display name.")
+            }
+        }
+        return nil, err
+    }
+
+    err = tx.Commit()
+    if err != nil {
+        return nil, err
+    }
+
+    role := &pb.Role{
+        Uuid: uuid,
+        DisplayName: displayName,
+        Slug: slug,
+        OrganizationUuid: fields.OrganizationUuid,
+        Generation: 1,
+    }
+
+    ctx.L2("Created new root role %s (%s)", slug, uuid)
+    return role, nil
+}
+
+// Updates information for an existing role by examining the fields
+// changed to the current fields values
+func RoleUpdate(
+    ctx *context.Context,
+    before *pb.Role,
+    changed *pb.RoleSetFields,
+) (*pb.Role, error) {
+    reset := ctx.LogSection("iam/db")
+    defer reset()
+    db := ctx.Db
+    uuid := before.Uuid
+    qs := "UPDATE roles SET "
+    changes := make(map[string]interface{}, 0)
+    newRole := &pb.Role{
+        Uuid: uuid,
+        Generation: before.Generation + 1,
+    }
+    if changed.DisplayName != nil {
+        newDisplayName := changed.DisplayName.Value
+        newSlug := slug.Make(newDisplayName)
+        changes["display_name"] = newDisplayName
+        changes["slug"] = newSlug
+        newRole.DisplayName = newDisplayName
+        newRole.Slug = newSlug
+    } else {
+        newRole.DisplayName = before.DisplayName
+        newRole.Slug = before.Slug
+    }
+    for field, _ := range changes {
+        qs = qs + fmt.Sprintf("%s = ?, ", field)
+    }
+    // Trim off the last comma and space
+    qs = qs[0:len(qs)-2]
+
+    qs = qs + "\nWHERE uuid = ? AND generation = ?"
+
+    ctx.LSQL(qs)
+
+    stmt, err := db.Prepare(qs)
+    if err != nil {
+        return nil, err
+    }
+    pargs := make([]interface{}, len(changes) + 2)
+    x := 0
+    for _, value := range changes {
+        pargs[x] = value
+        x++
+    }
+    pargs[x] = uuid
+    x++
+    pargs[x] = before.Generation
+    _, err = stmt.Exec(pargs...)
+    if err != nil {
+        me, ok := err.(*mysql.MySQLError)
+        if !ok {
+            return nil, err
+        }
+        if me.Number == 1062 {
+            // Duplicate key, check if it's the slug...
+            if strings.Contains(me.Error(), "uix_slug_root_organization_id") {
+                return nil, fmt.Errorf("Duplicate display name.")
+            }
+        }
+        return nil, err
+    }
+    return newRole, nil
 }

--- a/pkg/iam/server/role.go
+++ b/pkg/iam/server/role.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+    "fmt"
+
     "golang.org/x/net/context"
 
     pb "github.com/jaypipes/procession/proto"
@@ -24,4 +26,54 @@ func (s *Server) RoleGet(
         return nil, err
     }
     return role, nil
+}
+
+// RoleSet creates a new role or updates an existing
+// role
+func (s *Server) RoleSet(
+    ctx context.Context,
+    req *pb.RoleSetRequest,
+) (*pb.RoleSetResponse, error) {
+    reset := s.Ctx.LogSection("iam/server")
+    defer reset()
+    changed := req.Changed
+
+    if req.Search == nil {
+        s.Ctx.L3("Creating new role")
+
+        newRole, err := db.RoleCreate(
+            req.Session,
+            s.Ctx,
+            changed,
+        )
+        if err != nil {
+            return nil, err
+        }
+        resp := &pb.RoleSetResponse{
+            Role: newRole,
+        }
+        s.Ctx.L1("Created new role %s", newRole.Uuid)
+        return resp, nil
+    }
+
+    s.Ctx.L3("Updating role %s", req.Search.Value)
+
+    before, err := db.RoleGet(s.Ctx, req.Search.Value)
+    if err != nil {
+        return nil, err
+    }
+    if before.Uuid == "" {
+        notFound := fmt.Errorf("No such role found.")
+        return nil, notFound
+    }
+
+    newRole, err := db.RoleUpdate(s.Ctx, before, changed)
+    if err != nil {
+        return nil, err
+    }
+    resp := &pb.RoleSetResponse{
+        Role: newRole,
+    }
+    s.Ctx.L1("Updated role %s", newRole.Uuid)
+    return resp, nil
 }

--- a/proto/defs/service_iam.proto
+++ b/proto/defs/service_iam.proto
@@ -12,6 +12,9 @@ service IAM {
     // Returns information about a specific role
     rpc role_get(RoleGetRequest) returns (Role) {}
 
+    // Set information about a specific role
+    rpc role_set(RoleSetRequest) returns (RoleSetResponse) {}
+
     // Returns information about a specific user
     rpc user_get(UserGetRequest) returns (User) {}
 


### PR DESCRIPTION
A series of patches that adds support for creating and updating roles.

Role creation can be done using:

```
p7n role create --display-name members --permissions READ_ANY
```

Role updates currently only allow renaming the role:

```
p7n role update members --display-name "Read-only members"
```

Issue #11 