### PR TITLE
p7n: add simple permissions list command

### DIFF
--- a/p7n/commands/permissions.go
+++ b/p7n/commands/permissions.go
@@ -1,0 +1,67 @@
+package commands
+
+import (
+    "os"
+    "sort"
+
+    "github.com/olekukonko/tablewriter"
+    "github.com/spf13/cobra"
+
+    pb "github.com/jaypipes/procession/proto"
+)
+
+var permissionsCommand = &cobra.Command{
+    Use: "permissions",
+    Short: "Lists permissions that a role may have applied to it.",
+    Run: permissionsList,
+}
+
+type permRowComp func([]string, []string) bool
+func (comp permRowComp) sort(rows [][]string) {
+    ps := &permRowSorter{
+        rows: rows,
+        by: comp,
+    }
+    sort.Sort(ps)
+}
+
+type permRowSorter struct {
+    rows [][]string
+    by permRowComp
+}
+
+func (s *permRowSorter) Len() int {
+    return len(s.rows)
+}
+
+func (s *permRowSorter) Swap(i, j int) {
+    s.rows[i], s.rows[j] = s.rows[j], s.rows[i]
+}
+
+func (s *permRowSorter) Less(i, j int) bool {
+    return s.by(s.rows[i], s.rows[j])
+}
+
+func permissionsList(cmd *cobra.Command, args []string) {
+    headers := []string{
+        "Permission",
+    }
+    rows := make([][]string, len(pb.Permission_value) - 1)
+    x := 0
+    for perm, val := range pb.Permission_value {
+        if pb.Permission(val) == pb.Permission_END_PERMS {
+            continue
+        }
+        rows[x] = []string{perm}
+        x++
+    }
+    byName := func(s1, s2 []string) bool {
+        return s1[0] < s2[0]
+    }
+    permRowComp(byName).sort(rows)
+    table := tablewriter.NewWriter(os.Stdout)
+    table.SetHeader(headers)
+    table.AppendBulk(rows)
+    table.Render()
+    return
+}

--- a/p7n/commands/role_create.go
+++ b/p7n/commands/role_create.go
@@ -11,6 +11,14 @@ import (
     pb "github.com/jaypipes/procession/proto"
 )
 
+const (
+    permissionsHelpExtended = `
+
+    NOTE: To find out what permissions may be applied to a role, use
+          the p7n permissions command.
+`
+)
+
 var (
     roleCreateDisplayName string
     roleCreateOrganizationUuid string
@@ -40,7 +48,8 @@ func setupRoleCreateFlags() {
         &roleCreatePermissions,
         "permissions", "",
         "",
-        "Comma-separated list of permission strings to allow for this role.",
+        "Comma-separated list of permission strings to allow for this role." +
+        permissionsHelpExtended,
     )
 }
 

--- a/p7n/commands/root.go
+++ b/p7n/commands/root.go
@@ -108,6 +108,7 @@ func init() {
     RootCommand.AddCommand(userCommand)
     RootCommand.AddCommand(orgCommand)
     RootCommand.AddCommand(roleCommand)
+    RootCommand.AddCommand(permissionsCommand)
     RootCommand.AddCommand(meCommand)
     RootCommand.AddCommand(helpEnvCommand)
     RootCommand.SilenceUsage = true


### PR DESCRIPTION
Adds a simple `p7n permissions` command that lists out the permissions
that may be applied to a role.

Issue #11