### PR TITLE
authz: allow role update to set permissions

### DIFF
--- a/p7n/commands/role_create.go
+++ b/p7n/commands/role_create.go
@@ -11,14 +11,6 @@ import (
     pb "github.com/jaypipes/procession/proto"
 )
 
-const (
-    permissionsHelpExtended = `
-
-    NOTE: To find out what permissions may be applied to a role, use
-          the p7n permissions command.
-`
-)
-
 var (
     roleCreateDisplayName string
     roleCreateOrganizationUuid string

--- a/p7n/commands/root.go
+++ b/p7n/commands/root.go
@@ -38,6 +38,11 @@ const (
           user will need to query the result code from the p7n program
           in order to determine success.
 `
+    permissionsHelpExtended = `
+
+    NOTE: To find out what permissions may be applied to a role, use
+          the p7n permissions command.
+`
 )
 
 const (

--- a/pkg/iam/db/db.go
+++ b/pkg/iam/db/db.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+    "errors"
     "net"
     "strings"
     "syscall"
@@ -11,6 +12,10 @@ import (
 
     "github.com/jaypipes/procession/pkg/cfg"
     "github.com/jaypipes/procession/pkg/context"
+)
+
+var (
+    ERR_CONCURRENT_UPDATE = errors.New("Another thread updated this record concurrently. Please try your update again after refreshing your view of it.")
 )
 
 func inParamString(numArgs int) string {


### PR DESCRIPTION
Adds logic to the role update command to add or remove a set of
permissions from the role. In the process, we break out some repetitive
code into some utility functions in the pkg/iam/db/role module.

Issue #11