### PR TITLE
authz: clean up scoped role handling

### DIFF
--- a/p7n/commands/role_create.go
+++ b/p7n/commands/role_create.go
@@ -13,7 +13,7 @@ import (
 
 var (
     roleCreateDisplayName string
-    roleCreateOrganizationUuid string
+    roleCreateOrganization string
     roleCreatePermissions string
 )
 
@@ -31,10 +31,10 @@ func setupRoleCreateFlags() {
         "Display name for the role.",
     )
     roleCreateCommand.Flags().StringVarP(
-        &roleCreateOrganizationUuid,
-        "organization-uuid", "",
+        &roleCreateOrganization,
+        "organization", "",
         "",
-        "UUID of the organization that the role should be scoped to, if any.",
+        "Identifier of an organization the role should be scoped to, if any.",
     )
     roleCreateCommand.Flags().StringVarP(
         &roleCreatePermissions,
@@ -69,9 +69,9 @@ func roleCreate(cmd *cobra.Command, args []string) error {
         cmd.Usage()
         os.Exit(1)
     }
-    if cmd.Flags().Changed("organization-uuid") {
-        req.Changed.OrganizationUuid = &pb.StringValue{
-            Value: roleCreateOrganizationUuid,
+    if cmd.Flags().Changed("organization") {
+        req.Changed.Organization = &pb.StringValue{
+            Value: roleCreateOrganization,
         }
     }
     if cmd.Flags().Changed("permissions") {
@@ -100,8 +100,8 @@ func roleCreate(cmd *cobra.Command, args []string) error {
     } else {
         fmt.Printf("Successfully created role with UUID %s\n", role.Uuid)
         fmt.Printf("UUID:         %s\n", role.Uuid)
-        if role.OrganizationUuid != nil {
-            fmt.Printf("Organization: %s\n", role.OrganizationUuid.Value)
+        if role.Organization != nil {
+            fmt.Printf("Organization: %s\n", role.Organization.Value)
         }
         fmt.Printf("Display name: %s\n", role.DisplayName)
         fmt.Printf("Slug:         %s\n", role.Slug)

--- a/p7n/commands/role_get.go
+++ b/p7n/commands/role_get.go
@@ -39,8 +39,8 @@ func roleGet(cmd *cobra.Command, args []string) error {
         return nil
     }
     fmt.Printf("UUID:         %s\n", role.Uuid)
-    if role.OrganizationUuid != nil {
-        orgUuid := role.OrganizationUuid.Value
+    if role.Organization != nil {
+        orgUuid := role.Organization.Value
         fmt.Printf("Organization: %s\n", orgUuid)
     }
     fmt.Printf("Display name: %s\n", role.DisplayName)

--- a/p7n/commands/role_list.go
+++ b/p7n/commands/role_list.go
@@ -93,13 +93,19 @@ func roleList(cmd *cobra.Command, args []string) error {
         "UUID",
         "Display Name",
         "Slug",
+        "Organization",
     }
     rows := make([][]string, len(roles))
     for x, role := range roles {
+        org := ""
+        if role.Organization != nil {
+            org = role.Organization.Value
+        }
         rows[x] = []string{
             role.Uuid,
             role.DisplayName,
             role.Slug,
+            org,
         }
     }
     table := tablewriter.NewWriter(os.Stdout)

--- a/p7n/commands/role_update.go
+++ b/p7n/commands/role_update.go
@@ -13,7 +13,7 @@ import (
 
 var (
     roleUpdateDisplayName string
-    roleUpdateOrganizationUuid string
+    roleUpdateOrganization string
     roleUpdateAddPermissions string
     roleUpdateRemovePermissions string
 )
@@ -32,8 +32,8 @@ func setupRoleUpdateFlags() {
         "Display name for the role.",
     )
     roleUpdateCommand.Flags().StringVarP(
-        &roleUpdateOrganizationUuid,
-        "organization-uuid", "o",
+        &roleUpdateOrganization,
+        "organization", "o",
         "",
         "UUID of the organization the role should be scoped to, if any.",
     )
@@ -81,9 +81,9 @@ func roleUpdate(cmd *cobra.Command, args []string) error {
             Value: roleUpdateDisplayName,
         }
     }
-    if cmd.Flags().Changed("organization-uuid") {
-        req.Changed.OrganizationUuid = &pb.StringValue{
-            Value: roleUpdateOrganizationUuid,
+    if cmd.Flags().Changed("organization") {
+        req.Changed.Organization = &pb.StringValue{
+            Value: roleUpdateOrganization,
         }
     }
     if cmd.Flags().Changed("add") {
@@ -126,8 +126,8 @@ func roleUpdate(cmd *cobra.Command, args []string) error {
         role := resp.Role
         fmt.Printf("Successfully saved role %s\n", role.Uuid)
         fmt.Printf("UUID:         %s\n", role.Uuid)
-        if role.OrganizationUuid != nil {
-            fmt.Printf("Organization:       %s\n", role.OrganizationUuid.Value)
+        if role.Organization != nil {
+            fmt.Printf("Organization:       %s\n", role.Organization.Value)
         }
         fmt.Printf("Display name: %s\n", role.DisplayName)
         fmt.Printf("Slug:         %s\n", role.Slug)

--- a/pkg/iam/server/role.go
+++ b/pkg/iam/server/role.go
@@ -2,6 +2,7 @@ package server
 
 import (
     "fmt"
+    "database/sql"
 
     "golang.org/x/net/context"
 
@@ -23,14 +24,21 @@ func (s *Server) RoleList(
         return err
     }
     defer roleRows.Close()
-    role := pb.Role{}
     for roleRows.Next() {
+        role := pb.Role{}
+        var org sql.NullString
         err := roleRows.Scan(
             &role.Uuid,
             &role.DisplayName,
             &role.Slug,
             &role.Generation,
+            &org,
         )
+        if org.Valid {
+            role.Organization = &pb.StringValue{
+                Value: org.String,
+            }
+        }
         if err != nil {
             return err
         }

--- a/proto/defs/authz.proto
+++ b/proto/defs/authz.proto
@@ -54,7 +54,7 @@ message Role {
     string uuid = 1;
     string display_name = 2;
     string slug = 3;
-    StringValue organization_uuid = 4;
+    StringValue organization = 4;
     PermissionSet permission_set = 5;
     uint32 generation = 100;
 }
@@ -66,7 +66,7 @@ message RoleGetRequest {
 
 message RoleSetFields {
     StringValue display_name = 1;
-    StringValue organization_uuid = 2;
+    StringValue organization = 2;
     PermissionSet add = 3;
     PermissionSet remove = 4;
 }


### PR DESCRIPTION
This patch changes a few things to make the scoped role creation more
intuitive and also brings in the Organization column in the returned
table from `p7n role list`.

The previous `p7n role create --organization-uuid <ORG>` CLI option is
changed to just `p7n role create --organization <ORG>` and allows the
passing of a name, slug or UUID for the org.

Issue #11