### PR TITLE
Allow user roles to be set

### DIFF
--- a/p7n/commands/organization_members.go
+++ b/p7n/commands/organization_members.go
@@ -95,14 +95,13 @@ func orgMembersSet(cmd *cobra.Command, orgId string, args []string) error {
     if err != nil {
         return err
     }
-    printIf(verbose, "Added %d users to and %d users from %s\n",
+    printIf(verbose, "Added %d users to and removed %d users from %s\n",
             resp.NumAdded,
             resp.NumRemoved,
             orgId,
     )
-    fmt.Println("OK")
+    printIf(! quiet, "OK\n")
     return nil
-
 }
 
 func orgMembersList(cmd *cobra.Command, orgId string) error {

--- a/p7n/commands/user_roles.go
+++ b/p7n/commands/user_roles.go
@@ -4,6 +4,8 @@ import (
     "fmt"
     "io"
     "os"
+    "strings"
+
     "golang.org/x/net/context"
 
     "github.com/spf13/cobra"
@@ -16,21 +18,91 @@ var (
 )
 
 var userRolesCommand = &cobra.Command{
-    Use: "roles <user>",
-    Short: "List roles for a user",
+    Use: "roles <user> [add|remove <roles> ...]",
+    Short: "List and change roles for a user",
     RunE: userRoles,
 }
 
 func userRoles(cmd *cobra.Command, args []string) error {
     checkAuthUser(cmd)
-    if len(args) != 1 {
+    if len(args) < 1 {
         fmt.Println("Please specify a user identifier.")
         cmd.Usage()
         return nil
     }
 
     userRolesUserId = args[0]
-    return userRolesList(cmd, userRolesUserId)
+    if len(args) == 1 {
+        return userRolesList(cmd, userRolesUserId)
+    }
+    return userRolesSet(cmd, userRolesUserId, args[1:len(args)])
+}
+
+func userRolesSet(cmd *cobra.Command, userId string, args []string) error {
+    checkAuthUser(cmd)
+    toAdd := make([]string, 0)
+    toRemove := make([]string, 0)
+    for x := 0; x < len(args); x += 2 {
+        arg := strings.TrimSpace(args[x])
+        if (x + 1) < len(args) - 1 {
+            fmt.Println("Expected either 'add' or 'remove' followed " +
+                        "by comma-separated list of roles to add or remove")
+            cmd.Usage()
+            return nil
+        }
+        if arg == "add" {
+            toAdd = append(
+                toAdd,
+                strings.Split(
+                    strings.TrimSpace(
+                        args[x + 1],
+                    ),
+                    ",",
+                )...,
+            )
+        } else if arg == "remove" {
+            toRemove = append(
+                toRemove,
+                strings.Split(
+                    strings.TrimSpace(
+                        args[x + 1],
+                    ),
+                    ",",
+                )...,
+            )
+        } else {
+            fmt.Println("Unknown argument %s", arg)
+            cmd.Usage()
+            return nil
+        }
+    }
+
+    conn := connect()
+    defer conn.Close()
+
+    client := pb.NewIAMClient(conn)
+    req := &pb.UserRolesSetRequest{
+        Session: &pb.Session{User: authUser},
+        User: userId,
+    }
+    if len(toAdd) > 0 {
+        req.Add = toAdd
+    }
+    if len(toRemove) > 0 {
+        req.Remove = toRemove
+    }
+
+    resp, err := client.UserRolesSet(context.Background(), req)
+    if err != nil {
+        return err
+    }
+    printIf(verbose, "Added %d roles to and removed %d roles from %s\n",
+            resp.NumAdded,
+            resp.NumRemoved,
+            userId,
+    )
+    printIf(! quiet, "OK\n")
+    return nil
 }
 
 func userRolesList(cmd *cobra.Command, userId string) error {

--- a/pkg/iam/iamstorage/organization.go
+++ b/pkg/iam/iamstorage/organization.go
@@ -1217,30 +1217,7 @@ INSERT INTO organization_users (
             return 0, 0, err
         }
         defer stmt.Close()
-        res, err := stmt.Exec(qargs[0:c]...)
-        if err != nil {
-            return 0, 0, err
-        }
-        numAdded, err = res.RowsAffected()
-        if err != nil {
-            return 0, 0, err
-        }
-    }
-
-    if len(userIdsRemove) > 0 {
-        qs := `
-DELETE FROM organization_users
-WHERE organization_id = ?
-AND user_id ` + sqlutil.InParamString(len(userIdsRemove)) + `
-`
-        s.log.SQL(qs)
-
-        stmt, err := tx.Prepare(qs)
-        if err != nil {
-            return 0, 0, err
-        }
-        defer stmt.Close()
-        res, err := stmt.Exec(qargs[0:c]...)
+        res, err := stmt.Exec(qargs[0:addedQargs]...)
         if err != nil {
             return 0, 0, err
         }

--- a/pkg/iam/server/user.go
+++ b/pkg/iam/server/user.go
@@ -181,3 +181,27 @@ func (s *Server) UserRolesList(
     }
     return nil
 }
+
+// Add or remove roles from a user
+func (s *Server) UserRolesSet(
+    ctx context.Context,
+    req *pb.UserRolesSetRequest,
+) (*pb.UserRolesSetResponse, error) {
+    defer s.log.WithSection("iam/server")()
+
+    added, removed, err := s.storage.UserRolesSet(req)
+    if err != nil {
+        return nil, err
+    }
+    resp := &pb.UserRolesSetResponse{
+        NumAdded: added,
+        NumRemoved: removed,
+    }
+    s.log.L1(
+        "Updated roles for user  %s (added %d, removed %d)",
+         req.User,
+         added,
+         removed,
+    )
+    return resp, nil
+}

--- a/proto/defs/service_iam.proto
+++ b/proto/defs/service_iam.proto
@@ -39,6 +39,9 @@ service IAM {
     // List roles a user has
     rpc user_roles_list(UserRolesListRequest) returns (stream Role) {}
 
+    // Add or remove roles from a user
+    rpc user_roles_set(UserRolesSetRequest) returns (UserRolesSetResponse) {}
+
     // Returns information about a specific organization
     rpc organization_get(OrganizationGetRequest) returns (Organization) {}
 

--- a/proto/defs/user.proto
+++ b/proto/defs/user.proto
@@ -60,6 +60,18 @@ message UserRolesListRequest {
     string user = 2;
 }
 
+message UserRolesSetRequest {
+    Session session = 1;
+    string user = 2;
+    repeated string add = 3;
+    repeated string remove = 4;
+}
+
+message UserRolesSetResponse {
+    uint64 num_added = 1;
+    uint64 num_removed = 2;
+}
+
 message UserDeleteRequest {
     Session session = 1;
     string search = 2;


### PR DESCRIPTION
Adds a `p7n user roles <USER> [add|remove <ROLES>]` command and all
associated server-side plumbing to assign and remove roles to/from a
user.

Issue #11