### PR TITLE
For non-tabular output, show both name and UUID

### DIFF
--- a/p7n/commands/role_create.go
+++ b/p7n/commands/role_create.go
@@ -102,8 +102,9 @@ func roleCreate(cmd *cobra.Command, args []string) error {
         fmt.Printf("UUID:         %s\n", role.Uuid)
         if role.Organization != nil {
             fmt.Printf(
-                "Organization: %s\n",
+                "Organization: %s [%s)\n",
                 role.Organization.DisplayName,
+                role.Organization.Uuid,
             )
         }
         fmt.Printf("Display name: %s\n", role.DisplayName)

--- a/p7n/commands/role_get.go
+++ b/p7n/commands/role_get.go
@@ -40,8 +40,9 @@ func roleGet(cmd *cobra.Command, args []string) error {
     }
     fmt.Printf("UUID:         %s\n", role.Uuid)
     if role.Organization != nil {
+        orgUuid := role.Organization.Uuid
         orgName := role.Organization.DisplayName
-        fmt.Printf("Organization: %s\n", orgName)
+        fmt.Printf("Organization: %s [%s]\n", orgName, orgUuid)
     }
     fmt.Printf("Display name: %s\n", role.DisplayName)
     fmt.Printf("Slug:         %s\n", role.Slug)

--- a/p7n/commands/role_update.go
+++ b/p7n/commands/role_update.go
@@ -128,8 +128,9 @@ func roleUpdate(cmd *cobra.Command, args []string) error {
         fmt.Printf("UUID:         %s\n", role.Uuid)
         if role.Organization != nil {
             fmt.Printf(
-                "Organization:       %s\n",
+                "Organization:       %s [%s]\n",
                 role.Organization.DisplayName,
+                role.Organization.Uuid,
             )
         }
         fmt.Printf("Display name: %s\n", role.DisplayName)


### PR DESCRIPTION
When doing role get/create/update, output both the organization's name
as well as it's UUID.