### PR TITLE
Add ability to filter role list by organization

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -439,6 +439,28 @@ $ p7n role list --display-name Readers,Admins
 +----------------------------------+--------------+----------------+--------------+
 ```
 
+You may also filter by organization identifier, as this example shows:
+
+```
+$ p7n role list
++----------------------------------+--------------+----------------+--------------+
+|               UUID               | DISPLAY NAME |      SLUG      | ORGANIZATION |
++----------------------------------+--------------+----------------+--------------+
+| 560fdab66e8e4bdf98ab43f81dc9cee3 | Readers      | heroes-readers | Heroes       |
+| 37033fe0861842528dae6caa235f2346 | admins       | admins         |              |
+| 92c3bed3f4604eb5ae418c5ac05009ca | default      | default        |              |
++----------------------------------+--------------+----------------+--------------+
+
+$ p7n role list --organization heroes
++----------------------------------+--------------+----------------+--------------+
+|               UUID               | DISPLAY NAME |      SLUG      | ORGANIZATION |
++----------------------------------+--------------+----------------+--------------+
+| 560fdab66e8e4bdf98ab43f81dc9cee3 | Readers      | heroes-readers | Heroes       |
++----------------------------------+--------------+----------------+--------------+
+$ p7n role list --organization villains
+No records found matching search criteria.
+```
+
 To view information about a specific role, use the `p7n role get <ROLE>`
 command, supplying a UUID, display name or slug identifier:
 

--- a/p7n/commands/role_list.go
+++ b/p7n/commands/role_list.go
@@ -16,6 +16,7 @@ var (
     roleListUuid string
     roleListDisplayName string
     roleListSlug string
+    roleListOrganization string
 )
 
 var roleListCommand = &cobra.Command{
@@ -43,6 +44,12 @@ func setupRoleListFlags() {
         "",
         "Comma-delimited list of slugs to filter by.",
     )
+    roleListCommand.Flags().StringVarP(
+        &roleListOrganization,
+        "organization", "",
+        "",
+        "Comma-delimited list of organization identifiers to filter by.",
+    )
 }
 
 func init() {
@@ -60,6 +67,9 @@ func roleList(cmd *cobra.Command, args []string) error {
     }
     if cmd.Flags().Changed("slug") {
         filters.Slugs = strings.Split(roleListSlug, ",")
+    }
+    if cmd.Flags().Changed("organization") {
+        filters.Organizations = strings.Split(roleListOrganization, ",")
     }
     conn := connect()
     defer conn.Close()

--- a/proto/defs/authz.proto
+++ b/proto/defs/authz.proto
@@ -87,6 +87,7 @@ message RoleListFilters {
     repeated string uuids = 2;
     repeated string display_names = 3;
     repeated string slugs = 4;
+    repeated string organizations = 5;
 }
 
 message RoleListRequest {


### PR DESCRIPTION
Users can now filter roles listed with `p7n role list` by organization the role is in:

```
$ p7n role list
+----------------------------------+--------------+----------------+--------------+
|               UUID               | DISPLAY NAME |      SLUG      | ORGANIZATION |
+----------------------------------+--------------+----------------+--------------+
| 560fdab66e8e4bdf98ab43f81dc9cee3 | Readers      | heroes-readers | Heroes       |
| 37033fe0861842528dae6caa235f2346 | admins       | admins         |              |
| 92c3bed3f4604eb5ae418c5ac05009ca | default      | default        |              |
+----------------------------------+--------------+----------------+--------------+

$ p7n role list --organization heroes
+----------------------------------+--------------+----------------+--------------+
|               UUID               | DISPLAY NAME |      SLUG      | ORGANIZATION |
+----------------------------------+--------------+----------------+--------------+
| 560fdab66e8e4bdf98ab43f81dc9cee3 | Readers      | heroes-readers | Heroes       |
+----------------------------------+--------------+----------------+--------------+

$ p7n role list --organization villains
No records found matching search criteria.
```

Completes Issue #63 