### PR TITLE
make gsr registry unexported member of iam.Server

### DIFF
--- a/iam/main.go
+++ b/iam/main.go
@@ -7,16 +7,11 @@ import (
 
     "google.golang.org/grpc"
     "google.golang.org/grpc/credentials"
-    "github.com/jaypipes/gsr"
 
     pb "github.com/jaypipes/procession/proto"
 
     "github.com/jaypipes/procession/pkg/logging"
     "github.com/jaypipes/procession/pkg/iam/server"
-)
-
-const (
-    SERVICE_NAME = "procession-iam"
 )
 
 func main() {
@@ -40,20 +35,6 @@ func main() {
         os.Exit(1)
     }
     log.L2("listening on TCP %s", addr)
-
-    // Register this IAM service endpoint with the service registry
-    ep := gsr.Endpoint{
-        Service: &gsr.Service{SERVICE_NAME},
-        Address: addr,
-    }
-    err = srv.Registry.Register(&ep)
-    if err != nil {
-        log.ERR("unable to register %v with gsr: %v", ep, err)
-    }
-    log.L2(
-        "Registered IAM service endpoint running at %s with gsr.",
-        addr,
-    )
 
     // Set up the gRPC server listening on incoming TCP connections on our port
     var opts []grpc.ServerOption

--- a/pkg/iam/server/config.go
+++ b/pkg/iam/server/config.go
@@ -14,6 +14,7 @@ const (
     defaultUseTLS = false
     defaultBindPort = 10000
     defaultDSN = "user:password@/dbname"
+    defaultServiceName = "procession-iam"
 )
 
 var (
@@ -29,6 +30,7 @@ type Config struct {
     KeyPath string
     BindHost string
     BindPort int
+    ServiceName string
 }
 
 func ConfigFromOpts() *Config {
@@ -74,6 +76,13 @@ func ConfigFromOpts() *Config {
         ),
         "The port the server will listen on",
     )
+    optServiceName := flag.String(
+        "service-name",
+        env.EnvOrDefaultStr(
+            "PROCESSION_SERVICE_NAME", defaultServiceName,
+        ),
+        "Name of the service to register",
+    )
 
     flag.Parse()
 
@@ -84,5 +93,6 @@ func ConfigFromOpts() *Config {
         KeyPath: *optKeyPath,
         BindHost: *optHost,
         BindPort: *optPort,
+        ServiceName: *optServiceName,
     }
 }

--- a/pkg/iam/server/server.go
+++ b/pkg/iam/server/server.go
@@ -16,7 +16,7 @@ type Server struct {
     log *logging.Logs
     cfg *Config
     authz *authz.Authz
-    Registry *gsr.Registry
+    registry *gsr.Registry
     storage *iamstorage.IAMStorage
     events *events.Events
 }
@@ -56,11 +56,27 @@ func New(
     }
     log.L2("auth system initialized.")
 
+    // Register this IAM service endpoint with the service registry
+    addr := fmt.Sprintf("%s:%d", cfg.BindHost, cfg.BindPort)
+    ep := gsr.Endpoint{
+        Service: &gsr.Service{cfg.ServiceName},
+        Address: addr,
+    }
+    err = registry.Register(&ep)
+    if err != nil {
+        log.ERR("unable to register %v with gsr: %v", ep, err)
+    }
+    log.L2(
+        "registered %s service endpoint running at %s with gsr.",
+        cfg.ServiceName,
+        addr,
+    )
+
     s := &Server{
         log: log,
         cfg: cfg,
         authz: authz,
-        Registry: registry,
+        registry: registry,
         storage: storage,
     }
     return s, nil


### PR DESCRIPTION
Moves the final member of the pkg/iam/server:Server struct to be an
unexported member field. The gsr.Registry object was being set up
outside of pkg/iam/server:New() which meant it needed to be exported.
We undo that here and add a PROCESSION_SERVICE_NAME configuration
option and env variable to contain the needed configuration item for
setting up the gsr registry object inside of pkg/iam/server:New()