### PR TITLE
 bootstrap: create super users and role with p7n bootstrap command

### DIFF
--- a/deploy/dev-env.bash
+++ b/deploy/dev-env.bash
@@ -111,6 +111,7 @@ PROCESSION_SERVER_UNIT=`sudo systemd-run --slice=machine \
     --setenv PROCESSION_LOG_LEVEL=$PROCESSION_LOG_LEVEL \
     --setenv GSR_ETCD_ENDPOINTS=$GSR_ETCD_ENDPOINTS \
     --setenv PROCESSION_DSN=$PROCESSION_DSN \
+    --setenv PROCESSION_BOOTSTRAP_KEY=$PROCESSION_BOOTSTRAP_KEY \
     $ROOT_DIR/build/bin/procession-iamd 2>&1 | sed 's/\s\+//g' | cut -d':' -f2`
 echo "ok."
 echo "Procession IAM server running in $PROCESSION_SERVER_UNIT"

--- a/p7n/commands/bootstrap.go
+++ b/p7n/commands/bootstrap.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+    "fmt"
+    "os"
+
+    "golang.org/x/net/context"
+
+    "github.com/spf13/cobra"
+    pb "github.com/jaypipes/procession/proto"
+)
+
+var (
+    bootstrapKey string
+)
+
+var bootstrapCommand = &cobra.Command{
+    Use: "bootstrap",
+    Short: "Perform bootstrap actions",
+    RunE: bootstrap,
+}
+
+func setupBootstrapFlags() {
+    bootstrapCommand.Flags().StringVarP(
+        &bootstrapKey,
+        "key", "k",
+        "",
+        "The bootstrapping key.",
+    )
+}
+
+func init() {
+    setupBootstrapFlags()
+}
+
+func bootstrap(cmd *cobra.Command, args []string) error {
+    conn := connect()
+    defer conn.Close()
+
+    client := pb.NewIAMClient(conn)
+    req := &pb.BootstrapRequest{}
+
+    if cmd.Flags().Changed("key") {
+        req.Key = bootstrapKey
+    } else {
+        fmt.Println("Specify the bootstrap key using --key=<KEY>.")
+        cmd.Usage()
+        os.Exit(1)
+    }
+    _, err := client.Bootstrap(context.Background(), req)
+    if err != nil {
+        return err
+    }
+    printIf(! quiet, "OK\n")
+    return nil
+}

--- a/p7n/commands/bootstrap.go
+++ b/p7n/commands/bootstrap.go
@@ -3,6 +3,7 @@ package commands
 import (
     "fmt"
     "os"
+    "strings"
 
     "golang.org/x/net/context"
 
@@ -12,6 +13,8 @@ import (
 
 var (
     bootstrapKey string
+    bootstrapSuperUserEmails string
+    bootstrapSuperRoleName string
 )
 
 var bootstrapCommand = &cobra.Command{
@@ -26,6 +29,18 @@ func setupBootstrapFlags() {
         "key", "k",
         "",
         "The bootstrapping key.",
+    )
+    bootstrapCommand.Flags().StringVarP(
+        &bootstrapSuperUserEmails,
+        "super-user-email", "",
+        "",
+        "Comma-delimited list of emails to create super user accounts for.",
+    )
+    bootstrapCommand.Flags().StringVarP(
+        &bootstrapSuperRoleName,
+        "super-role-name", "k",
+        "admins",
+        "The name to use for a role containing the SUPER privilege.",
     )
 }
 
@@ -47,6 +62,16 @@ func bootstrap(cmd *cobra.Command, args []string) error {
         cmd.Usage()
         os.Exit(1)
     }
+
+    if cmd.Flags().Changed("super-users") {
+        req.SuperUserEmails = strings.Split(bootstrapSuperUserEmails, ",")
+    } else {
+        fmt.Println("Specify at least one email to use for super users using --super-user-email.")
+        cmd.Usage()
+        os.Exit(1)
+    }
+
+    req.SuperRoleName = bootstrapSuperRoleName
     _, err := client.Bootstrap(context.Background(), req)
     if err != nil {
         return err

--- a/p7n/commands/root.go
+++ b/p7n/commands/root.go
@@ -95,6 +95,7 @@ func init() {
     RootCommand.AddCommand(permissionsCommand)
     RootCommand.AddCommand(meCommand)
     RootCommand.AddCommand(helpEnvCommand)
+    RootCommand.AddCommand(bootstrapCommand)
     RootCommand.SilenceUsage = true
 
     clientLog = log.New(ioutil.Discard, "", 0)

--- a/pkg/iam/server/bootstrap.go
+++ b/pkg/iam/server/bootstrap.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+    "fmt"
+
+    "golang.org/x/net/context"
+
+    pb "github.com/jaypipes/procession/proto"
+)
+
+// Bootstrap checks a bootstrap key and creates a user with SUPER privileges
+func (s *Server) Bootstrap(
+    ctx context.Context,
+    req *pb.BootstrapRequest,
+) (*pb.BootstrapResponse, error) {
+    // The default value of the bootstrap key CLI/env option is "" which means
+    // the Procession service has to be explcitly started with a
+    // --bootstrap-key value in order for bootstrap operations, which don't
+    // check for any authentication/authorization, to be taken.
+    if s.cfg.BootstrapKey == "" {
+        return nil, fmt.Errorf("Invalid bootstrap key")
+    }
+
+    key := req.Key
+    if key == "" {
+        return nil, fmt.Errorf("Invalid bootstrap key")
+    }
+    if key != s.cfg.BootstrapKey {
+        return nil, fmt.Errorf("Invalid bootstrap key")
+    }
+
+    defer s.log.WithSection("iam/server")()
+
+    s.log.L1("Successful bootstrap operation.")
+
+    // Clear the bootstrap key to effectively make this a one-time operation
+    // TODO(jaypipes): Determine whether the affect of this reset in a
+    // multi-server environment is something we should care about?
+    s.cfg.BootstrapKey = ""
+    return &pb.BootstrapResponse{KeyReset: true}, nil
+}

--- a/pkg/iam/server/config.go
+++ b/pkg/iam/server/config.go
@@ -31,6 +31,7 @@ type Config struct {
     BindHost string
     BindPort int
     ServiceName string
+    BootstrapKey string
 }
 
 func ConfigFromOpts() *Config {
@@ -83,6 +84,13 @@ func ConfigFromOpts() *Config {
         ),
         "Name of the service to register",
     )
+    optBootstrapKey := flag.String(
+        "bootstrap-key",
+        env.EnvOrDefaultStr(
+            "PROCESSION_BOOTSTRAP_KEY", "",
+        ),
+        "Bootstrapping key. Please see documentating on bootstrapping",
+    )
 
     flag.Parse()
 
@@ -94,5 +102,6 @@ func ConfigFromOpts() *Config {
         BindHost: *optHost,
         BindPort: *optPort,
         ServiceName: *optServiceName,
+        BootstrapKey: *optBootstrapKey,
     }
 }

--- a/proto/defs/bootstrap.proto
+++ b/proto/defs/bootstrap.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package procession;
+
+message BootstrapRequest {
+    string key = 2;
+}
+
+message BootstrapResponse {
+    bool key_reset = 1;
+}

--- a/proto/defs/bootstrap.proto
+++ b/proto/defs/bootstrap.proto
@@ -3,7 +3,9 @@ syntax = "proto3";
 package procession;
 
 message BootstrapRequest {
-    string key = 2;
+    string key = 1;
+    string super_role_name = 2;
+    repeated string super_user_emails = 3;
 }
 
 message BootstrapResponse {

--- a/proto/defs/service_iam.proto
+++ b/proto/defs/service_iam.proto
@@ -3,12 +3,16 @@ syntax = "proto3";
 package procession;
 
 import "authz.proto";
+import "bootstrap.proto";
 import "organization.proto";
 import "user.proto";
 
 // The IAM gRPC service handles storage and operations for users,
 // organizations, authorization, etc.
 service IAM {
+    // Bootstrapping operation
+    rpc bootstrap(BootstrapRequest) returns (BootstrapResponse) {}
+
     // Returns information about a specific role
     rpc role_get(RoleGetRequest) returns (Role) {}
 

--- a/proto/defs/user.proto
+++ b/proto/defs/user.proto
@@ -23,8 +23,8 @@ message UserGetRequest {
 }
 
 message UserSetFields {
-    StringValue email = 2;
-    StringValue display_name = 3;
+    StringValue email = 1;
+    StringValue display_name = 2;
 }
 
 message UserSetRequest {


### PR DESCRIPTION
Adds foundations for a bootstrapping operation. We add a new
PROCESSION_BOOTSTRAP_KEY/--bootstrap-key flag to the IAM server. This
key must match a key supplied to a new `p7n bootstrap --key <KEY>`
command. This `p7n bootstrap` command will allow sending a payload
containing bootstrapping information like information for a user with
SUPER privileges or the default role information.

Adds the server-side plumbing and CLI tooling to support creating super
users and defining a role with the SUPER privilege using the `p7n
bootstrap` command