### PR TITLE
Add lookup IAM database user system permissions

### DIFF
--- a/p7n/commands/bootstrap.go
+++ b/p7n/commands/bootstrap.go
@@ -38,7 +38,7 @@ func setupBootstrapFlags() {
     )
     bootstrapCommand.Flags().StringVarP(
         &bootstrapSuperRoleName,
-        "super-role-name", "k",
+        "super-role-name", "",
         "admins",
         "The name to use for a role containing the SUPER privilege.",
     )
@@ -63,7 +63,7 @@ func bootstrap(cmd *cobra.Command, args []string) error {
         os.Exit(1)
     }
 
-    if cmd.Flags().Changed("super-users") {
+    if cmd.Flags().Changed("super-user-email") {
         req.SuperUserEmails = strings.Split(bootstrapSuperUserEmails, ",")
     } else {
         fmt.Println("Specify at least one email to use for super users using --super-user-email.")

--- a/pkg/authz/authz.go
+++ b/pkg/authz/authz.go
@@ -1,6 +1,7 @@
 package authz
 
 import (
+    "github.com/jaypipes/procession/pkg/iam/iamstorage"
     pb "github.com/jaypipes/procession/proto"
 )
 
@@ -28,9 +29,27 @@ func New() (*Authz, error) {
     return authz, nil
 }
 
+func NewWithStorage(storage *iamstorage.IAMStorage) (*Authz, error) {
+    entries := make(map[string]*cacheEntry, 10)
+    cache := &PermissionsCache{
+        storage: storage,
+        pmap: entries,
+    }
+    return &Authz{
+        cache: cache,
+    }, nil
+}
+
 func (a *Authz) sessionPermissions(
     sess *pb.Session,
 ) (*pb.Permissions) {
+    if a.cache == nil {
+        return &pb.Permissions{
+            System: &pb.PermissionSet{
+                Permissions: []pb.Permission{},
+            },
+        }
+    }
     return a.cache.get(sess)
 }
 

--- a/pkg/iam/server/server.go
+++ b/pkg/iam/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+    "errors"
     "fmt"
 
     "github.com/jaypipes/gsr"
@@ -10,6 +11,10 @@ import (
     "github.com/jaypipes/procession/pkg/logging"
 
     "github.com/jaypipes/procession/pkg/iam/iamstorage"
+)
+
+var (
+    ERR_FORBIDDEN = errors.New("User is not authorized to perform that action")
 )
 
 type Server struct {
@@ -50,7 +55,7 @@ func New(
     }
     log.L2("connected to DB.")
 
-    authz, err := authz.New()
+    authz, err := authz.NewWithStorage(storage)
     if err != nil {
         return nil, fmt.Errorf("failed to instantiate authz: %v", err)
     }


### PR DESCRIPTION
Modularizes the PermissionsCache in the authz package to pull
permissions information from the IAM database for a user.

Issue #11