### PR TITLE
correct loading of permissions in auth cache

### DIFF
--- a/pkg/authz/authz.go
+++ b/pkg/authz/authz.go
@@ -2,6 +2,7 @@ package authz
 
 import (
     "github.com/jaypipes/procession/pkg/iam/iamstorage"
+    "github.com/jaypipes/procession/pkg/logging"
     pb "github.com/jaypipes/procession/proto"
 )
 
@@ -21,21 +22,29 @@ type PermissionsGetter interface {
 }
 
 type Authz struct {
+    log *logging.Logs
     cache PermissionsGetter
 }
 
-func New() (*Authz, error) {
-    authz := &Authz{}
+func New(log *logging.Logs) (*Authz, error) {
+    authz := &Authz{
+        log: log,
+    }
     return authz, nil
 }
 
-func NewWithStorage(storage *iamstorage.IAMStorage) (*Authz, error) {
+func NewWithStorage(
+    log *logging.Logs,
+    storage *iamstorage.IAMStorage,
+) (*Authz, error) {
     entries := make(map[string]*cacheEntry, 10)
     cache := &PermissionsCache{
+        log: log,
         storage: storage,
         pmap: entries,
     }
     return &Authz{
+        log: log,
         cache: cache,
     }, nil
 }

--- a/pkg/iam/iamstorage/user.go
+++ b/pkg/iam/iamstorage/user.go
@@ -633,8 +633,7 @@ func (s *IAMStorage) UserSystemPermissions(
     // First verify the supplied user exists
     userId := s.userIdFromIdentifier(user)
     if userId == 0 {
-        notFound := fmt.Errorf("No such user %s", user)
-        return nil, notFound
+        return nil, storage.ERR_NOTFOUND_USER
     }
     qs := `
 SELECT

--- a/pkg/iam/server/bootstrap.go
+++ b/pkg/iam/server/bootstrap.go
@@ -50,7 +50,7 @@ func (s *Server) Bootstrap(
         if err != nil {
             return nil, err
         }
-        s.log.L1("Create role %s with SUPER privilege", req.SuperRoleName)
+        s.log.L1("Created role %s with SUPER privilege", req.SuperRoleName)
     }
 
     // Add user records for each email in the collection of super user emails

--- a/pkg/iam/server/organization.go
+++ b/pkg/iam/server/organization.go
@@ -17,6 +17,10 @@ func (s *Server) OrganizationList(
 ) error {
     defer s.log.WithSection("iam/server")()
 
+    if ! s.authz.Check(req.Session, pb.Permission_READ_ORGANIZATION) {
+        return ERR_FORBIDDEN
+    }
+
     s.log.L3("Listing organizations")
 
     orgRows, err := s.storage.OrganizationList(req.Filters)

--- a/pkg/iam/server/server.go
+++ b/pkg/iam/server/server.go
@@ -55,7 +55,7 @@ func New(
     }
     log.L2("connected to DB.")
 
-    authz, err := authz.NewWithStorage(storage)
+    authz, err := authz.NewWithStorage(log, storage)
     if err != nil {
         return nil, fmt.Errorf("failed to instantiate authz: %v", err)
     }

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -6,4 +6,5 @@ import (
 
 var (
     ERR_CONCURRENT_UPDATE = errors.New("Another thread updated this record concurrently. Please try your update again after refreshing your view of it.")
+    ERR_NOTFOUND_USER = errors.New("No such user")
 )


### PR DESCRIPTION
We were not properly loading permissions into the permissions cache in
a number of ways:

* we were not handling when the user was not found properly and
  returning nil and not setting a "blank" set of permissions in the
  user permissions map
* we were not returning the actual cache entry permissions when
  successfully loading from the DB

This patch fixes the above and adds logging into the auth cache layer

Issue #11