### PR TITLE
starts to clean up error handling

### DIFF
--- a/p7n/commands/common.go
+++ b/p7n/commands/common.go
@@ -56,7 +56,7 @@ func exitIfForbidden(err error) {
 func exitIfError(err error) {
     if s, ok := status.FromError(err); ok {
         if s.Code() != codes.OK {
-            fmt.Println("Error: %s", err)
+            fmt.Printf("Error: %s\n", s.Message())
             os.Exit(int(s.Code()))
         }
     }

--- a/p7n/commands/common.go
+++ b/p7n/commands/common.go
@@ -6,6 +6,8 @@ import (
 
     "github.com/spf13/cobra"
     "google.golang.org/grpc"
+    "google.golang.org/grpc/codes"
+    "google.golang.org/grpc/status"
 )
 
 const (
@@ -27,6 +29,7 @@ for the --user CLI option.
 Please check the PROCESSION_HOST and PROCESSION_PORT environment
 variables or --host and --port  CLI options.
 `
+    errForbidden = `Error: you are not authorized to perform that action.`
 )
 
 const (
@@ -37,6 +40,25 @@ func exitIfConnectErr(err error) {
     if err != nil {
         fmt.Println(errConnect)
         os.Exit(1)
+    }
+}
+
+func exitIfForbidden(err error) {
+    if s, ok := status.FromError(err); ok {
+        if s.Code() == codes.PermissionDenied {
+            fmt.Println(errForbidden)
+            os.Exit(int(s.Code()))
+        }
+    }
+}
+
+// Writes a generic error to output and exits if supplied error is an error
+func exitIfError(err error) {
+    if s, ok := status.FromError(err); ok {
+        if s.Code() != codes.OK {
+            fmt.Println("Error: %s", err)
+            os.Exit(int(s.Code()))
+        }
     }
 }
 

--- a/p7n/commands/organization_create.go
+++ b/p7n/commands/organization_create.go
@@ -17,7 +17,7 @@ var (
 var orgCreateCommand = &cobra.Command{
     Use: "create",
     Short: "Creates a new organization",
-    RunE: orgCreate,
+    Run: orgCreate,
 }
 
 func setupOrgCreateFlags() {
@@ -39,7 +39,7 @@ func init() {
     setupOrgCreateFlags()
 }
 
-func orgCreate(cmd *cobra.Command, args []string) error {
+func orgCreate(cmd *cobra.Command, args []string) {
     checkAuthUser(cmd)
     conn := connect()
     defer conn.Close()
@@ -65,14 +65,14 @@ func orgCreate(cmd *cobra.Command, args []string) error {
         }
     }
     resp, err := client.OrganizationSet(context.Background(), req)
-    if err != nil {
-        return err
-    }
+    exitIfError(err)
     org := resp.Organization
     if quiet {
         fmt.Println(org.Uuid)
     } else {
         fmt.Printf("Successfully created organization with UUID %s\n", org.Uuid)
+    }
+    if verbose {
         fmt.Printf("UUID:         %s\n", org.Uuid)
         fmt.Printf("Display name: %s\n", org.DisplayName)
         fmt.Printf("Slug:         %s\n", org.Slug)
@@ -84,5 +84,4 @@ func orgCreate(cmd *cobra.Command, args []string) error {
             )
         }
     }
-    return nil
 }

--- a/p7n/commands/organization_delete.go
+++ b/p7n/commands/organization_delete.go
@@ -2,6 +2,7 @@ package commands
 
 import (
     "fmt"
+    "os"
     "golang.org/x/net/context"
 
     "github.com/spf13/cobra"
@@ -11,15 +12,15 @@ import (
 var orgDeleteCommand = &cobra.Command{
     Use: "delete <organization>",
     Short: "Deletes an organization and all of its resources",
-    RunE: orgDelete,
+    Run: orgDelete,
 }
 
-func orgDelete(cmd *cobra.Command, args []string) error {
+func orgDelete(cmd *cobra.Command, args []string) {
     checkAuthUser(cmd)
     if len(args) != 1 {
         fmt.Println("Please specify an organization identifier.")
         cmd.Usage()
-        return nil
+        os.Exit(1)
     }
     conn := connect()
     defer conn.Close()
@@ -32,10 +33,7 @@ func orgDelete(cmd *cobra.Command, args []string) error {
     }
 
     _, err := client.OrganizationDelete(context.Background(), req)
-    if err != nil {
-        return err
-    }
+    exitIfError(err)
     printIf(verbose, "Successfully deleted organization %s\n", orgId)
     printIf(! quiet, "OK\n")
-    return nil
 }

--- a/p7n/commands/organization_get.go
+++ b/p7n/commands/organization_get.go
@@ -30,9 +30,7 @@ func orgGet(cmd *cobra.Command, args []string) error {
         Search: args[0],
     }
     org, err := client.OrganizationGet(context.Background(), req)
-    if err != nil {
-        return err
-    }
+    exitIfError(err)
     if org.Uuid == "" {
         fmt.Printf("No organization found matching request\n")
         return nil

--- a/p7n/commands/organization_list.go
+++ b/p7n/commands/organization_list.go
@@ -22,7 +22,7 @@ var (
 var orgListCommand = &cobra.Command{
     Use: "list",
     Short: "List information about organizations",
-    RunE: orgList,
+    Run: orgList,
 }
 
 func setupOrgListFlags() {
@@ -56,7 +56,7 @@ func init() {
     setupOrgListFlags()
 }
 
-func orgList(cmd *cobra.Command, args []string) error {
+func orgList(cmd *cobra.Command, args []string) {
     checkAuthUser(cmd)
     filters := &pb.OrganizationListFilters{}
     if cmd.Flags().Changed("uuid") {
@@ -77,9 +77,7 @@ func orgList(cmd *cobra.Command, args []string) error {
         Filters: filters,
     }
     stream, err := client.OrganizationList(context.Background(), req)
-    if err != nil {
-        return err
-    }
+    exitIfError(err)
 
     orgs := make([]*pb.Organization, 0)
     for {
@@ -87,9 +85,8 @@ func orgList(cmd *cobra.Command, args []string) error {
         if err == io.EOF {
             break
         }
-        if err != nil {
-            return err
-        }
+        exitIfForbidden(err)
+        exitIfError(err)
         orgs = append(orgs, org)
     }
     if len(orgs) == 0 {
@@ -100,7 +97,6 @@ func orgList(cmd *cobra.Command, args []string) error {
     } else {
         orgListViewTree(&orgs)
     }
-    return nil
 }
 
 func orgListViewTable(orgs *[]*pb.Organization) {

--- a/p7n/commands/organization_members.go
+++ b/p7n/commands/organization_members.go
@@ -19,25 +19,25 @@ var (
 var orgMembersCommand = &cobra.Command{
     Use: "members <organization> [add|remove <users> ...]",
     Short: "List and change members of an organization",
-    RunE: orgMembers,
+    Run: orgMembers,
 }
 
-func orgMembers(cmd *cobra.Command, args []string) error {
+func orgMembers(cmd *cobra.Command, args []string) {
     checkAuthUser(cmd)
     if len(args) < 1 {
         fmt.Println("Please specify an organization identifier.")
         cmd.Usage()
-        return nil
+        os.Exit(1)
     }
     orgMembersOrgId = args[0]
 
     if len(args) == 1 {
-        return orgMembersList(cmd, orgMembersOrgId)
+        orgMembersList(cmd, orgMembersOrgId)
     }
-    return orgMembersSet(cmd, orgMembersOrgId, args[1:len(args)])
+    orgMembersSet(cmd, orgMembersOrgId, args[1:len(args)])
 }
 
-func orgMembersSet(cmd *cobra.Command, orgId string, args []string) error {
+func orgMembersSet(cmd *cobra.Command, orgId string, args []string) {
     toAdd := make([]string, 0)
     toRemove := make([]string, 0)
     for x := 0; x < len(args); x += 2 {
@@ -46,7 +46,7 @@ func orgMembersSet(cmd *cobra.Command, orgId string, args []string) error {
             fmt.Println("Expected either 'add' or 'remove' followed " +
                         "by comma-separated list of users to add or remove")
             cmd.Usage()
-            return nil
+            os.Exit(1)
         }
         if arg == "add" {
             toAdd = append(
@@ -73,7 +73,7 @@ func orgMembersSet(cmd *cobra.Command, orgId string, args []string) error {
             fmt.Println("Expected either 'add' or 'remove' followed " +
                         "by comma-separated list of users to add or remove")
             cmd.Usage()
-            return nil
+            os.Exit(1)
         }
     }
 
@@ -93,19 +93,16 @@ func orgMembersSet(cmd *cobra.Command, orgId string, args []string) error {
     }
 
     resp, err := client.OrganizationMembersSet(context.Background(), req)
-    if err != nil {
-        return err
-    }
+    exitIfError(err)
     printIf(verbose, "Added %d users to and removed %d users from %s\n",
             resp.NumAdded,
             resp.NumRemoved,
             orgId,
     )
     printIf(! quiet, "OK\n")
-    return nil
 }
 
-func orgMembersList(cmd *cobra.Command, orgId string) error {
+func orgMembersList(cmd *cobra.Command, orgId string) {
     conn := connect()
     defer conn.Close()
 
@@ -118,9 +115,7 @@ func orgMembersList(cmd *cobra.Command, orgId string) error {
         context.Background(),
         req,
     )
-    if err != nil {
-        return err
-    }
+    exitIfError(err)
 
     users := make([]*pb.User, 0)
     for {
@@ -128,9 +123,7 @@ func orgMembersList(cmd *cobra.Command, orgId string) error {
         if err == io.EOF {
             break
         }
-        if err != nil {
-            return err
-        }
+        exitIfError(err)
         users = append(users, user)
     }
     if len(users) == 0 {
@@ -155,5 +148,4 @@ func orgMembersList(cmd *cobra.Command, orgId string) error {
     table.SetHeader(headers)
     table.AppendBulk(rows)
     table.Render()
-    return nil
 }

--- a/p7n/commands/organization_update.go
+++ b/p7n/commands/organization_update.go
@@ -17,7 +17,7 @@ var (
 var orgUpdateCommand = &cobra.Command{
     Use: "update <identifier>",
     Short: "Updates information for an organization",
-    RunE: orgUpdate,
+    Run: orgUpdate,
 }
 
 func setupOrgUpdateFlags() {
@@ -39,7 +39,7 @@ func init() {
     setupOrgUpdateFlags()
 }
 
-func orgUpdate(cmd *cobra.Command, args []string) error {
+func orgUpdate(cmd *cobra.Command, args []string) {
     checkAuthUser(cmd)
     conn := connect()
     defer conn.Close()
@@ -69,9 +69,7 @@ func orgUpdate(cmd *cobra.Command, args []string) error {
         }
     }
     resp, err := client.OrganizationSet(context.Background(), req)
-    if err != nil {
-        return err
-    }
+    exitIfError(err)
     if ! quiet {
         org := resp.Organization
         fmt.Printf("Successfully saved organization %s\n", org.Uuid)
@@ -86,5 +84,4 @@ func orgUpdate(cmd *cobra.Command, args []string) error {
             )
         }
     }
-    return nil
 }

--- a/p7n/commands/user_create.go
+++ b/p7n/commands/user_create.go
@@ -17,7 +17,7 @@ var (
 var userCreateCommand = &cobra.Command{
     Use: "create",
     Short: "Creates a new user",
-    RunE: userCreate,
+    Run: userCreate,
 }
 
 func setupUserCreateFlags() {
@@ -39,7 +39,7 @@ func init() {
     setupUserCreateFlags()
 }
 
-func userCreate(cmd *cobra.Command, args []string) error {
+func userCreate(cmd *cobra.Command, args []string) {
     checkAuthUser(cmd)
     conn := connect()
     defer conn.Close()
@@ -69,18 +69,17 @@ func userCreate(cmd *cobra.Command, args []string) error {
         os.Exit(1)
     }
     resp, err := client.UserSet(context.Background(), req)
-    if err != nil {
-        return err
-    }
+    exitIfError(err)
     user := resp.User
     if quiet {
         fmt.Println(user.Uuid)
     } else {
         fmt.Printf("Successfully created user with UUID %s\n", user.Uuid)
+    }
+    if verbose {
         fmt.Printf("UUID:         %s\n", user.Uuid)
         fmt.Printf("Display name: %s\n", user.DisplayName)
         fmt.Printf("Email:        %s\n", user.Email)
         fmt.Printf("Slug:         %s\n", user.Slug)
     }
-    return nil
 }

--- a/p7n/commands/user_delete.go
+++ b/p7n/commands/user_delete.go
@@ -2,6 +2,8 @@ package commands
 
 import (
     "fmt"
+    "os"
+
     "golang.org/x/net/context"
 
     "github.com/spf13/cobra"
@@ -11,15 +13,15 @@ import (
 var userDeleteCommand = &cobra.Command{
     Use: "delete <user>",
     Short: "Deletes a user and all of its resources",
-    RunE: userDelete,
+    Run: userDelete,
 }
 
-func userDelete(cmd *cobra.Command, args []string) error {
+func userDelete(cmd *cobra.Command, args []string) {
     checkAuthUser(cmd)
     if len(args) != 1 {
         fmt.Println("Please specify a user identifier.")
         cmd.Usage()
-        return nil
+        os.Exit(1)
     }
     conn := connect()
     defer conn.Close()
@@ -32,9 +34,7 @@ func userDelete(cmd *cobra.Command, args []string) error {
     }
 
     _, err := client.UserDelete(context.Background(), req)
-    if err != nil {
-        return err
-    }
-    fmt.Printf("Successfully deleted user %s\n", userId)
-    return nil
+    exitIfError(err)
+    printIf(verbose, "Successfully deleted user %s\n", userId)
+    printIf(! quiet, "OK\n")
 }

--- a/p7n/commands/user_get.go
+++ b/p7n/commands/user_get.go
@@ -2,6 +2,8 @@ package commands
 
 import (
     "fmt"
+    "os"
+
     "golang.org/x/net/context"
 
     "github.com/spf13/cobra"
@@ -11,18 +13,15 @@ import (
 var userGetCommand = &cobra.Command{
     Use: "get <search>",
     Short: "Get information for a single user",
-    RunE: userGet,
+    Run: userGet,
 }
 
-func init() {
-}
-
-func userGet(cmd *cobra.Command, args []string) error {
+func userGet(cmd *cobra.Command, args []string) {
     checkAuthUser(cmd)
     if len(args) == 0 {
         fmt.Println("Please specify an email, UUID, name or slug to search for.")
         cmd.Usage()
-        return nil
+        os.Exit(1)
     }
     conn := connect()
     defer conn.Close()
@@ -33,16 +32,9 @@ func userGet(cmd *cobra.Command, args []string) error {
         Search: args[0],
     }
     user, err := client.UserGet(context.Background(), req)
-    if err != nil {
-        return err
-    }
-    if user.Uuid == "" {
-        fmt.Printf("No user found matching request\n")
-        return nil
-    }
+    exitIfError(err)
     fmt.Printf("UUID:         %s\n", user.Uuid)
     fmt.Printf("Display name: %s\n", user.DisplayName)
     fmt.Printf("Email:        %s\n", user.Email)
     fmt.Printf("Slug:         %s\n", user.Slug)
-    return nil
 }

--- a/p7n/commands/user_members.go
+++ b/p7n/commands/user_members.go
@@ -18,22 +18,22 @@ var (
 var userMembersCommand = &cobra.Command{
     Use: "members <user>",
     Short: "List organizations this user is a member of",
-    RunE: userMembers,
+    Run: userMembers,
 }
 
-func userMembers(cmd *cobra.Command, args []string) error {
+func userMembers(cmd *cobra.Command, args []string) {
     checkAuthUser(cmd)
     if len(args) != 1 {
         fmt.Println("Please specify a user identifier.")
         cmd.Usage()
-        return nil
+        os.Exit(1)
     }
 
     userMembersUserId = args[0]
-    return userMembersList(cmd, userMembersUserId)
+    userMembersList(cmd, userMembersUserId)
 }
 
-func userMembersList(cmd *cobra.Command, userId string) error {
+func userMembersList(cmd *cobra.Command, userId string) {
     checkAuthUser(cmd)
     conn := connect()
     defer conn.Close()
@@ -47,9 +47,7 @@ func userMembersList(cmd *cobra.Command, userId string) error {
         context.Background(),
         req,
     )
-    if err != nil {
-        return err
-    }
+    exitIfError(err)
 
     orgs := make([]*pb.Organization, 0)
     for {
@@ -57,9 +55,7 @@ func userMembersList(cmd *cobra.Command, userId string) error {
         if err == io.EOF {
             break
         }
-        if err != nil {
-            return err
-        }
+        exitIfError(err)
         orgs = append(orgs, org)
     }
     if len(orgs) == 0 {
@@ -88,5 +84,4 @@ func userMembersList(cmd *cobra.Command, userId string) error {
     table.SetHeader(headers)
     table.AppendBulk(rows)
     table.Render()
-    return nil
 }

--- a/p7n/commands/user_update.go
+++ b/p7n/commands/user_update.go
@@ -17,7 +17,7 @@ var (
 var userUpdateCommand = &cobra.Command{
     Use: "update <identifier>",
     Short: "Updates information for a user",
-    RunE: userUpdate,
+    Run: userUpdate,
 }
 
 func setupUserUpdateFlags() {
@@ -39,7 +39,7 @@ func init() {
     setupUserUpdateFlags()
 }
 
-func userUpdate(cmd *cobra.Command, args []string) error {
+func userUpdate(cmd *cobra.Command, args []string) {
     checkAuthUser(cmd)
     conn := connect()
     defer conn.Close()
@@ -69,14 +69,12 @@ func userUpdate(cmd *cobra.Command, args []string) error {
         }
     }
     resp, err := client.UserSet(context.Background(), req)
-    if err != nil {
-        return err
-    }
+    exitIfError(err)
     user := resp.User
-    fmt.Printf("Successfully saved user <%s>\n", user.Uuid)
-    fmt.Printf("UUID:         %s\n", user.Uuid)
-    fmt.Printf("Display name: %s\n", user.DisplayName)
-    fmt.Printf("Email:        %s\n", user.Email)
-    fmt.Printf("Slug:         %s\n", user.Slug)
-    return nil
+    printIf(! quiet || verbose, "OK\n")
+    printIf(verbose, "Successfully saved user <%s>\n", user.Uuid)
+    printIf(verbose, "UUID:         %s\n", user.Uuid)
+    printIf(verbose, "Display name: %s\n", user.DisplayName)
+    printIf(verbose, "Email:        %s\n", user.Email)
+    printIf(verbose, "Slug:         %s\n", user.Slug)
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -9,3 +9,12 @@ var (
         "User is not authorized to perform that action",
     )
 )
+
+func NOTFOUND(objType string, identifier string) error {
+    return status.Errorf(
+        codes.NotFound,
+        "No such %s %s",
+        objType,
+        identifier,
+    )
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,11 @@
+package errors
+
+import "google.golang.org/grpc/status"
+import "google.golang.org/grpc/codes"
+
+var (
+    FORBIDDEN = status.Error(
+        codes.PermissionDenied,
+        "User is not authorized to perform that action",
+    )
+)

--- a/pkg/iam/iamstorage/organization.go
+++ b/pkg/iam/iamstorage/organization.go
@@ -9,9 +9,10 @@ import (
     "github.com/go-sql-driver/mysql"
     "github.com/golang/protobuf/proto"
 
-    "github.com/jaypipes/procession/pkg/util"
+    "github.com/jaypipes/procession/pkg/errors"
     "github.com/jaypipes/procession/pkg/sqlutil"
     "github.com/jaypipes/procession/pkg/storage"
+    "github.com/jaypipes/procession/pkg/util"
     pb "github.com/jaypipes/procession/proto"
 )
 
@@ -182,8 +183,7 @@ WHERE `
     }
 
     if orgId == 0 {
-        notFound := fmt.Errorf("No such organization found.")
-        return notFound
+        return errors.NOTFOUND("organization", search)
     }
 
     before := &pb.Organization{
@@ -1226,8 +1226,7 @@ func (s *IAMStorage) OrganizationMembersSet(
     orgSearch := req.Organization
     orgId := s.orgIdFromIdentifier(orgSearch)
     if orgId == 0 {
-        notFound := fmt.Errorf("No such organization found.")
-        return 0, 0, notFound
+        return 0, 0, errors.NOTFOUND("organization", orgSearch)
     }
 
     tx, err := s.Begin()
@@ -1242,8 +1241,7 @@ func (s *IAMStorage) OrganizationMembersSet(
     for _, identifier := range req.Add {
         userId := s.userIdFromIdentifier(identifier)
         if userId == 0 {
-            notFound := fmt.Errorf("No such user %s.", identifier)
-            return 0, 0, notFound
+            return 0, 0, errors.NOTFOUND("user", identifier)
         }
         userIdsAdd = append(userIdsAdd, userId)
     }
@@ -1251,8 +1249,7 @@ func (s *IAMStorage) OrganizationMembersSet(
     for _, identifier := range req.Remove {
         userId := s.userIdFromIdentifier(identifier)
         if userId == 0 {
-            notFound := fmt.Errorf("No such user %s.", identifier)
-            return 0, 0, notFound
+            return 0, 0, errors.NOTFOUND("user", identifier)
         }
         userIdsRemove = append(userIdsRemove, userId)
     }
@@ -1360,8 +1357,7 @@ func (s *IAMStorage) OrganizationMembersList(
     orgSearch := req.Organization
     orgId := s.orgIdFromIdentifier(orgSearch)
     if orgId == 0 {
-        notFound := fmt.Errorf("No such organization found.")
-        return nil, notFound
+        return nil, errors.NOTFOUND("organization", orgSearch)
     }
     // Below, we use the nested sets modeling to identify users for the target
     // organization and all of that organization's predecessors (ascendants).

--- a/pkg/iam/server/organization.go
+++ b/pkg/iam/server/organization.go
@@ -7,6 +7,7 @@ import (
     "golang.org/x/net/context"
 
     pb "github.com/jaypipes/procession/proto"
+    "github.com/jaypipes/procession/pkg/errors"
 )
 
 // OrganizationList looks up zero or more organization records matching
@@ -18,7 +19,7 @@ func (s *Server) OrganizationList(
     defer s.log.WithSection("iam/server")()
 
     if ! s.authz.Check(req.Session, pb.Permission_READ_ORGANIZATION) {
-        return ERR_FORBIDDEN
+        return errors.FORBIDDEN
     }
 
     s.log.L3("Listing organizations")

--- a/pkg/iam/server/organization.go
+++ b/pkg/iam/server/organization.go
@@ -2,7 +2,6 @@ package server
 
 import (
     "database/sql"
-    "fmt"
 
     "golang.org/x/net/context"
 
@@ -125,15 +124,15 @@ func (s *Server) OrganizationSet(
         return resp, nil
     }
 
-    s.log.L3("Updating organization %s", req.Search.Value)
+    search := req.Search.Value
+    s.log.L3("Updating organization %s", search)
 
     before, err := s.storage.OrganizationGet(req.Search.Value)
     if err != nil {
         return nil, err
     }
     if before.Uuid == "" {
-        notFound := fmt.Errorf("No such organization found.")
-        return nil, notFound
+        return nil, errors.NOTFOUND("organization", search)
     }
 
     newOrg, err := s.storage.OrganizationUpdate(before, changed)

--- a/pkg/iam/server/server.go
+++ b/pkg/iam/server/server.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-    "errors"
     "fmt"
 
     "github.com/jaypipes/gsr"
@@ -11,10 +10,6 @@ import (
     "github.com/jaypipes/procession/pkg/logging"
 
     "github.com/jaypipes/procession/pkg/iam/iamstorage"
-)
-
-var (
-    ERR_FORBIDDEN = errors.New("User is not authorized to perform that action")
 )
 
 type Server struct {

--- a/pkg/iam/server/user.go
+++ b/pkg/iam/server/user.go
@@ -2,11 +2,11 @@ package server
 
 import (
     "database/sql"
-    "fmt"
 
     "golang.org/x/net/context"
 
     pb "github.com/jaypipes/procession/proto"
+    "github.com/jaypipes/procession/pkg/errors"
 )
 
 // UserGet looks up a user record by user identifier and returns the
@@ -91,13 +91,16 @@ func (s *Server) UserSet(
         s.log.L1("Created new user %s", newUser.Uuid)
         return resp, nil
     }
-    before, err := s.storage.UserGet(req.Search.Value)
+
+    search := req.Search.Value
+    s.log.L3("Updating user %s", search)
+
+    before, err := s.storage.UserGet(search)
     if err != nil {
         return nil, err
     }
     if before.Uuid == "" {
-        notFound := fmt.Errorf("No such user found.")
-        return nil, notFound
+        return nil, errors.NOTFOUND("user", search)
     }
 
     newUser, err := s.storage.UserUpdate(before, changed)


### PR DESCRIPTION
Adds a new pkg/errors package with standardized error messages and
codes. Uses the grpc.status package to construct errors that grpc
understands and transforms the organization list p7n command and
associated server-side code to use the single pkg/errors:FORBIDDEN
error added here.

Adds graceful error handling to organization and user p7n commands. In
the process, also cleans up a number of p7n commands that were not
respecting the quiet and verbose options.

Issue #52