### PR TITLE
simplify organization list interface

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -229,14 +229,14 @@ by supplying a comma-delimited list of things to search for, as these examples
 show:
 
 ```
-$ p7n organization list --uuid 10b4e38038c911e7940fe06995034837
+$ p7n organization list 10b4e38038c911e7940fe06995034837
 +----------------------------------+--------------+----------+--------+
 |               UUID               | DISPLAY NAME |   SLUG   | PARENT |
 +----------------------------------+----------------+--------+--------+
 | 10b4e38038c911e7940fe06995034837 | Cartoons     | cartoons |        |
 +----------------------------------+--------------+----------+--------+
 
-$ p7n organization list --slug the-flintstones,cartoons
+$ p7n organization list the-flintstones,cartoons
 +----------------------------------+----------------+-----------------+----------+
 |               UUID               |  DISPLAY NAME  |      SLUG       |  PARENT  |
 +----------------------------------+----------------+-----------------+----------+

--- a/p7n/commands/organization_list.go
+++ b/p7n/commands/organization_list.go
@@ -13,37 +13,16 @@ import (
 )
 
 var (
-    orgListUuid string
-    orgListDisplayName string
-    orgListSlug string
     orgListShowTree bool
 )
 
 var orgListCommand = &cobra.Command{
-    Use: "list",
+    Use: "list [<identifier>,...]",
     Short: "List information about organizations",
     Run: orgList,
 }
 
 func setupOrgListFlags() {
-    orgListCommand.Flags().StringVarP(
-        &orgListUuid,
-        "uuid", "u",
-        "",
-        "Comma-separated list of UUIDs to filter by",
-    )
-    orgListCommand.Flags().StringVarP(
-        &orgListDisplayName,
-        "display-name", "n",
-        "",
-        "Comma-separated list of display names to filter by",
-    )
-    orgListCommand.Flags().StringVarP(
-        &orgListSlug,
-        "slug", "",
-        "",
-        "Comma-delimited list of slugs to filter by.",
-    )
     orgListCommand.Flags().BoolVarP(
         &orgListShowTree,
         "tree", "t",
@@ -59,14 +38,8 @@ func init() {
 func orgList(cmd *cobra.Command, args []string) {
     checkAuthUser(cmd)
     filters := &pb.OrganizationListFilters{}
-    if cmd.Flags().Changed("uuid") {
-        filters.Uuids = strings.Split(orgListUuid, ",")
-    }
-    if cmd.Flags().Changed("display-name") {
-        filters.DisplayNames = strings.Split(orgListDisplayName, ",")
-    }
-    if cmd.Flags().Changed("slug") {
-        filters.Slugs = strings.Split(orgListSlug, ",")
+    if len(args) > 0 {
+        filters.Identifiers = strings.Split(args[0], ",")
     }
     conn := connect()
     defer conn.Close()

--- a/proto/defs/organization.proto
+++ b/proto/defs/organization.proto
@@ -42,9 +42,7 @@ message OrganizationSetResponse {
 }
 
 message OrganizationListFilters {
-    repeated string uuids = 1;
-    repeated string display_names = 2;
-    repeated string slugs = 3;
+    repeated string identifiers = 1;
 }
 
 message OrganizationListRequest {


### PR DESCRIPTION
Instead of having the user need to specify --display-name or --slug or
--uuid CLI options, turn the `p7n organization list` interface into a
simpler `p7n organization list <search>` interface and determine
whether the supplied search identifiers are UUIDs or not on the server
side.

Issue #86