### PR TITLE
Simplify user list operations

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -78,7 +78,7 @@ by supplying a comma-delimited list of things to search for, as these examples
 show:
 
 ```
-$ go run p7n/main.go user list --slug fred-flintstone
+$ go run p7n/main.go user list fred-flintstone
 +----------------------------------+-----------------+----------------------------+-----------------+
 |               UUID               |  DISPLAY NAME   |           EMAIL            |      SLUG       |
 +----------------------------------+-----------------+----------------------------+-----------------+
@@ -87,7 +87,7 @@ $ go run p7n/main.go user list --slug fred-flintstone
 ```
 
 ```
-$ p7n user list --email fflintstone@yabbadabba.com,speedy@gonzalez.com
+$ p7n user list fflintstone@yabbadabba.com,8509e0699503483711e73802066a89c6
 +----------------------------------+-----------------+----------------------------+-----------------+
 |               UUID               |  DISPLAY NAME   |           EMAIL            |      SLUG       |
 +----------------------------------+-----------------+----------------------------+-----------------+

--- a/proto/defs/user.proto
+++ b/proto/defs/user.proto
@@ -42,10 +42,7 @@ message UserSetResponse {
 }
 
 message UserListFilters {
-    repeated string uuids = 1;
-    repeated string display_names = 2;
-    repeated string emails = 3;
-    repeated string slugs = 4;
+    repeated string identifiers = 1;
 }
 
 message UserListRequest {


### PR DESCRIPTION
Removes the CLI options for --display-name, --email, --slug and --uuid
from the `p7n user list` operations, allowing callers to just list
identifiers (email, slug, UUID or display name).

Closes Issue #92