### PR TITLE
Simplify role list operations

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -401,21 +401,21 @@ You can filter the results of the command by specifying one or more names,
 slugs or UUIDs, as in these examples:
 
 ```
-$ p7n role list --uuid 92c3bed3f4604eb5ae418c5ac05009ca
+$ p7n role list 92c3bed3f4604eb5ae418c5ac05009ca
 +----------------------------------+--------------+---------+--------------+
 |               UUID               | DISPLAY NAME |  SLUG   | ORGANIZATION |
 +----------------------------------+--------------+---------+--------------+
 | 92c3bed3f4604eb5ae418c5ac05009ca | default      | default |              |
 +----------------------------------+--------------+---------+--------------+
 
-$ p7n role list --slug admins
+$ p7n role list admins
 +----------------------------------+--------------+--------+--------------+
 |               UUID               | DISPLAY NAME |  SLUG  | ORGANIZATION |
 +----------------------------------+--------------+--------+--------------+
 | 37033fe0861842528dae6caa235f2346 | admins       | admins |              |
 +----------------------------------+--------------+--------+--------------+
 
-$ p7n role list --display-name Readers,Admins
+$ p7n role list Readers,Admins
 +----------------------------------+--------------+----------------+--------------+
 |               UUID               | DISPLAY NAME |      SLUG      | ORGANIZATION |
 +----------------------------------+--------------+----------------+--------------+

--- a/p7n/commands/role_list.go
+++ b/p7n/commands/role_list.go
@@ -13,9 +13,6 @@ import (
 )
 
 var (
-    roleListUuid string
-    roleListDisplayName string
-    roleListSlug string
     roleListOrganization string
 )
 
@@ -26,24 +23,6 @@ var roleListCommand = &cobra.Command{
 }
 
 func setupRoleListFlags() {
-    roleListCommand.Flags().StringVarP(
-        &roleListUuid,
-        "uuid", "u",
-        "",
-        "Comma-separated list of UUIDs to filter by",
-    )
-    roleListCommand.Flags().StringVarP(
-        &roleListDisplayName,
-        "display-name", "n",
-        "",
-        "Comma-separated list of display names to filter by",
-    )
-    roleListCommand.Flags().StringVarP(
-        &roleListSlug,
-        "slug", "",
-        "",
-        "Comma-delimited list of slugs to filter by.",
-    )
     roleListCommand.Flags().StringVarP(
         &roleListOrganization,
         "organization", "",
@@ -59,14 +38,8 @@ func init() {
 func roleList(cmd *cobra.Command, args []string) {
     checkAuthUser(cmd)
     filters := &pb.RoleListFilters{}
-    if cmd.Flags().Changed("uuid") {
-        filters.Uuids = strings.Split(roleListUuid, ",")
-    }
-    if cmd.Flags().Changed("display-name") {
-        filters.DisplayNames = strings.Split(roleListDisplayName, ",")
-    }
-    if cmd.Flags().Changed("slug") {
-        filters.Slugs = strings.Split(roleListSlug, ",")
+    if len(args) > 0 {
+        filters.Identifiers = strings.Split(args[0], ",")
     }
     if cmd.Flags().Changed("organization") {
         filters.Organizations = strings.Split(roleListOrganization, ",")

--- a/proto/defs/role.proto
+++ b/proto/defs/role.proto
@@ -42,11 +42,8 @@ message RoleSetResponse {
 }
 
 message RoleListFilters {
-    StringValue organization = 1;
-    repeated string uuids = 2;
-    repeated string display_names = 3;
-    repeated string slugs = 4;
-    repeated string organizations = 5;
+    repeated string identifiers = 1;
+    repeated string organizations = 2;
 }
 
 message RoleListRequest {


### PR DESCRIPTION
Removes the `--display-name`, `--uuid` and `--slug` CLI options from
the `p7n role list` command, allowing callers to pass a comma-delimited
list of identifiers as a CLI argument.

Closes Issue #93