### PR TITLE
Allow specifying roles during user creation

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -46,6 +46,35 @@ Email:        fred@flintstone.com
 Slug:         fred-flintstone
 ```
 
+#### Specifying roles during user creation
+
+You can specify which roles a user should have when you create the user. To do
+so, simply specify the `--roles` CLI option, passing a comma-delimited list of
+role identifiers (UUIDs, slugs) for the user to have:
+
+```
+$ p7n role list
++----------------------------------+---------------+------------------------+--------------+
+|               UUID               | DISPLAY NAME  |          SLUG          | ORGANIZATION |
++----------------------------------+---------------+------------------------+--------------+
+| 840c2b246a684546ba4dbc5fd9b703c5 | Cartoon Stars | cartoons-cartoon-stars | Cartoons     |
+| 485bd3c477134868957da60edbc3fab3 | Admins        | admins                 |              |
+| 0a63d64aba7649618250d488fb48f8fd | Readers       | readers                |              |
++----------------------------------+---------------+------------------------+--------------+
+
+$ p7n user create --display-name "Barney Rubble" --email barney@rubble.com --roles readers
+Successfully created user with UUID d238c9ddf3f74145aeb1c5bcb2c80fa9
+
+$ p7n user get d238c9ddf3f74145aeb1c5bcb2c80fa9 --roles
+UUID:         d238c9ddf3f74145aeb1c5bcb2c80fa9
+Display name: Barney Rubble
+Email:        barney@rubble.com
+Slug:         barney-rubble
+Roles:        Readers
+```
+
+#### Updating user information
+
 You may edit the user's information using the `p7n user update <search>`
 command, supplying the user's UUID, email, display name or slug as the
 `<search>` string:
@@ -60,6 +89,29 @@ Display name: Fred Flintstone
 Email:        fflintstone@yabbadabba.com
 Slug:         fred-flintstone
 ```
+
+#### Deleting users
+
+To delete a user, use the `p7n user delete <user>` command, supplying a user's
+slug, email or UUID:
+
+```
+$ p7n user get betty-rubble
+UUID:         1f5627c4797f404485005982edf84354
+Display name: Betty Rubble
+Email:        betty@rubble.com
+Slug:         betty-rubble
+
+$ p7n user delete betty-rubble
+OK
+```
+
+**Note**: Deleting a user will delete all the user's memberships in any
+organizations and any resources owned by the user. If a user is deleted and the
+user was the sole member of an organization, that organization and its
+resources are also deleted.
+
+### Searching for user information
 
 To show a tabular view of zero or more users, call the `p7n user list` command:
 
@@ -100,26 +152,8 @@ $ p7n user list fflintstone@yabbadabba.com,8509e0699503483711e73802066a89c6
 are allowed to view based on your access and permissions. See the
 "Authorization concepts" section below for more details.
 
-To delete a user, use the `p7n user delete <user>` command, supplying a user's
-slug, email or UUID:
 
-```
-$ p7n user get betty-rubble
-UUID:         1f5627c4797f404485005982edf84354
-Display name: Betty Rubble
-Email:        betty@rubble.com
-Slug:         betty-rubble
-
-$ p7n user delete betty-rubble
-OK
-```
-
-**Note**: Deleting a user will delete all the user's memberships in any
-organizations and any resources owned by the user. If a user is deleted and the
-user was the sole member of an organization, that organization and its
-resources are also deleted.
-
-### Viewing a user's memberships
+#### Viewing a user's memberships
 
 A user can be a member in one or more organizations. To view the organizations
 a user is a member of, use the `p7n user members <user>` command, as the

--- a/p7n/commands/common.go
+++ b/p7n/commands/common.go
@@ -22,6 +22,14 @@ const (
 )
 
 const (
+    rolesHelpExtended = `
+
+    NOTE: To find out what roles a user may be added to, use
+          the p7n role list command.
+`
+)
+
+const (
     errUnsetUser = `Error: unable to find the authenticating user.
 
 Please set the PROCESSION_USER environment variable or supply a value

--- a/pkg/authz/authz.go
+++ b/pkg/authz/authz.go
@@ -49,6 +49,9 @@ func (a *Authz) Check(
     sess *pb.Session,
     checked pb.Permission,
 ) bool {
+    if sess == nil {
+        return false
+    }
     perms := a.getUserPermissions(sess)
     if perms == nil {
         return false

--- a/pkg/iam/server/user.go
+++ b/pkg/iam/server/user.go
@@ -26,45 +26,55 @@ func (s *Server) UserGet(
         return nil, err
     }
     if req.WithRoles {
-        rolesReq := &pb.UserRolesListRequest{
-            Session: req.Session,
-            User: user.Uuid,
-        }
-        roleRows, err := s.storage.UserRolesList(rolesReq)
+        err = s.loadUserRoles(req.Session, user)
         if err != nil {
             return nil, err
         }
-        roles := make([]*pb.Role, 0)
-        defer roleRows.Close()
-        for roleRows.Next() {
-            role := &pb.Role{}
-            var orgName sql.NullString
-            var orgSlug sql.NullString
-            var orgUuid sql.NullString
-            err := roleRows.Scan(
-                &role.Uuid,
-                &role.DisplayName,
-                &role.Slug,
-                &orgName,
-                &orgSlug,
-                &orgUuid,
-            )
-            if err != nil {
-                return nil, err
-            }
-            if orgName.Valid {
-                org := &pb.Organization{
-                    Uuid: orgUuid.String,
-                    DisplayName: orgName.String,
-                    Slug: orgSlug.String,
-                }
-                role.Organization = org
-            }
-            roles = append(roles, role);
-        }
-        user.Roles = roles
     }
     return user, nil
+}
+
+// Looks up roles for a user and sets the pb.User.Roles message field to a list
+// of pb.Role messages
+func (s *Server) loadUserRoles(sess *pb.Session, user *pb.User) error {
+    rolesReq := &pb.UserRolesListRequest{
+        Session: sess,
+        User: user.Uuid,
+    }
+    roleRows, err := s.storage.UserRolesList(rolesReq)
+    if err != nil {
+        return err
+    }
+    roles := make([]*pb.Role, 0)
+    defer roleRows.Close()
+    for roleRows.Next() {
+        role := &pb.Role{}
+        var orgName sql.NullString
+        var orgSlug sql.NullString
+        var orgUuid sql.NullString
+        err := roleRows.Scan(
+            &role.Uuid,
+            &role.DisplayName,
+            &role.Slug,
+            &orgName,
+            &orgSlug,
+            &orgUuid,
+        )
+        if err != nil {
+            return err
+        }
+        if orgName.Valid {
+            org := &pb.Organization{
+                Uuid: orgUuid.String,
+                DisplayName: orgName.String,
+                Slug: orgSlug.String,
+            }
+            role.Organization = org
+        }
+        roles = append(roles, role);
+    }
+    user.Roles = roles
+    return nil
 }
 
 // Deletes a user, all of its membership records and owned resources
@@ -138,6 +148,12 @@ func (s *Server) UserSet(
         newUser, err := s.storage.UserCreate(changed)
         if err != nil {
             return nil, err
+        }
+        if changed.Roles != nil {
+            err = s.loadUserRoles(req.Session, newUser)
+            if err != nil {
+                return nil, err
+            }
         }
         resp := &pb.UserSetResponse{
             User: newUser,

--- a/proto/defs/user.proto
+++ b/proto/defs/user.proto
@@ -29,6 +29,7 @@ message UserGetRequest {
 message UserSetFields {
     StringValue email = 1;
     StringValue display_name = 2;
+    repeated string roles = 101;
 }
 
 message UserSetRequest {


### PR DESCRIPTION
Allows the user to specify one or more roles for the new user to have during
user creation.

Issue #76