### PR TITLE
Filter orgs by visibility and user relation

### DIFF
--- a/pkg/iam/server/organization.go
+++ b/pkg/iam/server/organization.go
@@ -23,7 +23,7 @@ func (s *Server) OrganizationList(
 
     s.log.L3("Listing organizations")
 
-    orgRows, err := s.storage.OrganizationList(req.Filters)
+    orgRows, err := s.storage.OrganizationList(req.Session, req.Filters)
     if err != nil {
         return err
     }


### PR DESCRIPTION
Modifies the list organizations operation to only return organizations
with public visibility OR organizations that are private but where the
user belongs to the organization or a parent

Issue #86