### PR TITLE
Set organization visibility on creation

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -8,6 +8,10 @@ var (
         codes.PermissionDenied,
         "User is not authorized to perform that action",
     )
+    INVALID_PUBLIC_CHILD_PRIVATE_PARENT = status.Error(
+        codes.InvalidArgument,
+        "Cannot make a child organization public if its parent is private.",
+    )
 )
 
 func NOTFOUND(objType string, identifier string) error {


### PR DESCRIPTION
Sets new organization visibility to PUBLIC or PRIVATE when specified on
the command line. For child organizations, we return an error if the
caller attempts to create a PUBLIC organization under a PRIVATE parent
org.

Issue #86