### PR TITLE
start of support for search/list options

### DIFF
--- a/p7n/commands/common.go
+++ b/p7n/commands/common.go
@@ -51,6 +51,16 @@ const (
     msgNoRecords = "No records found matching search criteria."
 )
 
+// Some commonly-used CLI options
+const (
+    defaultListLimit = 20
+)
+
+var (
+    listLimit int
+    listMarker string
+)
+
 // Checks the given string to ensure it matches an appropriate value for a
 // visibility setting and returns the matching integer value or exits with a
 // usage message
@@ -122,4 +132,31 @@ func printIf(b bool, msg string, args ...interface{}) {
     if b {
         fmt.Printf(msg, args...)
     }
+}
+
+// Appends the standard listing CLI options to the supplied command struct
+func addListOptions(cmd *cobra.Command) {
+    cmd.Flags().IntVarP(
+        &listLimit,
+        "limit", "",
+        defaultListLimit,
+        "Number of records to limit results to.",
+    )
+    cmd.Flags().StringVarP(
+        &listMarker,
+        "marker", "",
+        "",
+        "Identifier of the last record on the previous page of results.",
+    )
+}
+
+// Examines the supplied search listing options and returns a constructed
+// pb.SearchOptions message struct for use in the request to the Procession
+// service
+func buildSearchOptions(cmd *cobra.Command) *pb.SearchOptions {
+    res := &pb.SearchOptions{
+        Limit: uint32(listLimit),
+        Marker: listMarker,
+    }
+    return res
 }

--- a/p7n/commands/organization_list.go
+++ b/p7n/commands/organization_list.go
@@ -29,6 +29,7 @@ func setupOrgListFlags() {
         false,
         "Show orgs in a tree view.",
     )
+    addListOptions(orgListCommand)
 }
 
 func init() {
@@ -48,6 +49,7 @@ func orgList(cmd *cobra.Command, args []string) {
     req := &pb.OrganizationListRequest{
         Session: &pb.Session{User: authUser},
         Filters: filters,
+        Options: buildSearchOptions(cmd),
     }
     stream, err := client.OrganizationList(context.Background(), req)
     exitIfError(err)

--- a/pkg/iam/iamstorage/organization.go
+++ b/pkg/iam/iamstorage/organization.go
@@ -28,6 +28,7 @@ type orgRecord struct {
 func (s *IAMStorage) OrganizationList(
     sess *pb.Session,
     filters *pb.OrganizationListFilters,
+    opts *pb.SearchOptions,
 ) (storage.RowIterator, error) {
     user, err := s.userRecord(sess.User)
     if err != nil {
@@ -82,6 +83,9 @@ OR (o.visibility = 0 AND private_orgs.id IS NOT NULL)
         }
         qs = qs + ")"
     }
+    qs = qs + "\nORDER BY o.uuid"
+    qs = qs + "\nLIMIT ?"
+    qargs = append(qargs, opts.Limit)
 
     rows, err := s.Rows(qs, qargs...)
     if err != nil {

--- a/pkg/iam/server/organization.go
+++ b/pkg/iam/server/organization.go
@@ -23,7 +23,11 @@ func (s *Server) OrganizationList(
 
     s.log.L3("Listing organizations")
 
-    orgRows, err := s.storage.OrganizationList(req.Session, req.Filters)
+    orgRows, err := s.storage.OrganizationList(
+        req.Session,
+        req.Filters,
+        req.Options,
+    )
     if err != nil {
         return err
     }

--- a/proto/defs/search.proto
+++ b/proto/defs/search.proto
@@ -7,8 +7,14 @@ enum SortDirection {
     DESC = 1;
 }
 
+message SortField {
+    string field = 1;
+    SortDirection direction = 2;
+}
+
 // Options for sorting and pagination of list queries
 message SearchOptions {
-    repeated string sort_fields = 1;
-    repeated SortDirection sort_directions = 2;
+    uint32 limit = 1;
+    string marker = 2;
+    repeated SortField sort_fields = 3;
 }


### PR DESCRIPTION
Allows specifying a `--limit` CLI option to `p7n organization list` to limit the number of results returned. Hard-codes UUID sort order for now. Lots more work to come on this.

Issue #58