### PR TITLE
Add basic sorting functionality for organization list operation

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -63,3 +63,11 @@ organization %s's membership or manually delete the organization.`,
         org,
     )
 }
+
+func INVALID_SORT_FIELD(field string) error {
+    return status.Errorf(
+        codes.InvalidArgument,
+        "Invalid sort field '%s'",
+        field,
+    )
+}

--- a/pkg/iam/server/organization.go
+++ b/pkg/iam/server/organization.go
@@ -23,11 +23,7 @@ func (s *Server) OrganizationList(
 
     s.log.L3("Listing organizations")
 
-    orgRows, err := s.storage.OrganizationList(
-        req.Session,
-        req.Filters,
-        req.Options,
-    )
+    orgRows, err := s.storage.OrganizationList(req)
     if err != nil {
         return err
     }

--- a/pkg/sqlutil/sqlutil.go
+++ b/pkg/sqlutil/sqlutil.go
@@ -1,9 +1,12 @@
 package sqlutil
 
 import (
+    "fmt"
     "strings"
 
     "github.com/go-sql-driver/mysql"
+
+    pb "github.com/jaypipes/procession/proto"
 )
 
 // Returns a string containing the expression IN with one or more question
@@ -57,4 +60,27 @@ func IsDuplicateKeyOn(err error, constraintName string) bool {
         return false
     }
     return strings.Contains(me.Error(), constraintName)
+}
+
+// Extends the supplied raw SQL string with an ORDER BY clause based on a
+// pb.SearchOptions message and a table alias
+func AddOrderBy(qs *string, opts *pb.SearchOptions, alias string) {
+    *qs = *qs + "\nORDER BY "
+    for x, sortField := range opts.SortFields {
+        comma := ""
+        if x > 0 {
+            comma = ","
+        }
+        aliasStr := alias
+        if alias != "" && ! strings.Contains(alias, ".") {
+            aliasStr = aliasStr + "."
+        }
+        *qs = *qs + fmt.Sprintf(
+            "%s%s%s %s",
+            comma,
+            aliasStr,
+            sortField.Field,
+            sortField.Direction,
+        )
+    }
 }

--- a/pkg/sqlutil/sqlutil_test.go
+++ b/pkg/sqlutil/sqlutil_test.go
@@ -4,6 +4,8 @@ import (
     "testing"
 
     "github.com/stretchr/testify/assert"
+
+    pb "github.com/jaypipes/procession/proto"
 )
 
 func TestInParamString(t *testing.T) {
@@ -12,4 +14,38 @@ func TestInParamString(t *testing.T) {
     assert.Equal("IN (?)", InParamString(1))
     assert.Equal("IN (?, ?)", InParamString(2))
     assert.Equal("IN (?, ?, ?)", InParamString(3))
+}
+
+func TestAddOrderBy(t *testing.T) {
+    assert := assert.New(t)
+
+    qs := "SELECT o.id, o.name FROM orders AS o"
+    opts := &pb.SearchOptions{
+        SortFields: []*pb.SortField{
+            &pb.SortField{
+                Field: "id",
+                Direction: pb.SortDirection_ASC,
+            },
+        },
+    }
+
+    AddOrderBy(&qs, opts, "o")
+    expect := `SELECT o.id, o.name FROM orders AS o
+ORDER BY o.id ASC`
+    assert.Equal(expect, qs)
+
+    qs = "SELECT o.id, o.name FROM orders AS o"
+    opts = &pb.SearchOptions{
+        SortFields: []*pb.SortField{
+            &pb.SortField{
+                Field: "name",
+                Direction: pb.SortDirection_DESC,
+            },
+        },
+    }
+
+    AddOrderBy(&qs, opts, "o")
+    expect = `SELECT o.id, o.name FROM orders AS o
+ORDER BY o.name DESC`
+    assert.Equal(expect, qs)
 }


### PR DESCRIPTION
Adds basic functionality to specify a sort field and direction in the p7n CLI, validate the asked-for sort fields on the server side and properly sort the results that come back.

Issue #58