### PR TITLE
refactor sqlutil.NormalizeSortField and fix broken bootstrap command

### DIFF
--- a/pkg/iam/iamstorage/organization.go
+++ b/pkg/iam/iamstorage/organization.go
@@ -15,16 +15,20 @@ import (
 )
 
 var (
-    validOrgSortFields = []string{
-        "uuid",
-        "name",
-        "display name",
-        "display_name",
-    }
-    orgSortFieldAliases = map[string]string{
-        "name": "display_name",
-        "display name": "display_name",
-        "display_name": "display_name",
+    orgSortFields = []*sqlutil.SortFieldInfo{
+        &sqlutil.SortFieldInfo{
+            Name: "uuid",
+            Unique: true,
+        },
+        &sqlutil.SortFieldInfo{
+            Name: "display_name",
+            Unique: false,
+            Aliases: []string{
+                "name",
+                "display name",
+                "display_name",
+            },
+        },
     }
 )
 
@@ -47,8 +51,7 @@ func (s *IAMStorage) OrganizationList(
     opts := req.Options
     err := sqlutil.NormalizeSortFields(
         opts,
-        &validOrgSortFields,
-        &orgSortFieldAliases,
+        &orgSortFields,
     )
     if err != nil {
         return nil, err

--- a/pkg/iam/iamstorage/role.go
+++ b/pkg/iam/iamstorage/role.go
@@ -14,16 +14,20 @@ import (
 )
 
 var (
-    validRoleSortFields = []string{
-        "uuid",
-        "name",
-        "display name",
-        "display_name",
-    }
-    roleSortFieldAliases = map[string]string{
-        "name": "display_name",
-        "display name": "display_name",
-        "display_name": "display_name",
+    roleSortFields = []*sqlutil.SortFieldInfo{
+        &sqlutil.SortFieldInfo{
+            Name: "uuid",
+            Unique: true,
+        },
+        &sqlutil.SortFieldInfo{
+            Name: "display_name",
+            Unique: true,
+            Aliases: []string{
+                "name",
+                "display name",
+                "display_name",
+            },
+        },
     }
 )
 
@@ -34,11 +38,7 @@ func (s *IAMStorage) RoleList(
 ) (storage.RowIterator, error) {
     filters := req.Filters
     opts := req.Options
-    err := sqlutil.NormalizeSortFields(
-        opts,
-        &validRoleSortFields,
-        &roleSortFieldAliases,
-    )
+    err := sqlutil.NormalizeSortFields(opts, &roleSortFields)
     if err != nil {
         return nil, err
     }

--- a/pkg/iam/iamstorage/user.go
+++ b/pkg/iam/iamstorage/user.go
@@ -15,17 +15,24 @@ import (
 )
 
 var (
-    validUserSortFields = []string{
-        "uuid",
-        "email",
-        "name",
-        "display name",
-        "display_name",
-    }
-    userSortFieldAliases = map[string]string{
-        "name": "display_name",
-        "display name": "display_name",
-        "display_name": "display_name",
+    userSortFields = []*sqlutil.SortFieldInfo{
+        &sqlutil.SortFieldInfo{
+            Name: "uuid",
+            Unique: true,
+        },
+        &sqlutil.SortFieldInfo{
+            Name: "email",
+            Unique: true,
+        },
+        &sqlutil.SortFieldInfo{
+            Name: "display_name",
+            Unique: false,
+            Aliases: []string{
+                "name",
+                "display name",
+                "display_name",
+            },
+        },
     }
 )
 
@@ -43,11 +50,7 @@ func (s *IAMStorage) UserList(
 ) (storage.RowIterator, error) {
     filters := req.Filters
     opts := req.Options
-    err := sqlutil.NormalizeSortFields(
-        opts,
-        &validUserSortFields,
-        &userSortFieldAliases,
-    )
+    err := sqlutil.NormalizeSortFields(opts, &userSortFields)
     if err != nil {
         return nil, err
     }

--- a/pkg/iam/server/bootstrap.go
+++ b/pkg/iam/server/bootstrap.go
@@ -5,6 +5,7 @@ import (
 
     "golang.org/x/net/context"
 
+    "github.com/jaypipes/procession/pkg/errors"
     pb "github.com/jaypipes/procession/proto"
 )
 
@@ -54,10 +55,10 @@ func (s *Server) Bootstrap(
     // Add user records for each email in the collection of super user emails
     for _, email := range req.SuperUserEmails {
         user, err := s.storage.UserGet(email)
-        if err != nil {
+        if err != nil && ! errors.IsNotFound(err) {
             return nil, err
         }
-        if user.Uuid == "" {
+        if errors.IsNotFound(err) {
             newFields := &pb.UserSetFields{
                 DisplayName: &pb.StringValue{
                     Value: email,

--- a/pkg/sqlutil/sqlutil_test.go
+++ b/pkg/sqlutil/sqlutil_test.go
@@ -121,17 +121,24 @@ AND o.uuid < ?`
 func TestNormalizeSortFields(t *testing.T) {
     assert := assert.New(t)
 
-    validSortFields := []string{
-        "uuid",
-        "email",
-        "name",
-        "display name",
-        "display_name",
-    }
-    sortFieldAliases := map[string]string{
-        "name": "display_name",
-        "display name": "display_name",
-        "display_name": "display_name",
+    sortFieldInfos := []*SortFieldInfo{
+        &SortFieldInfo{
+            Name: "uuid",
+            Unique: true,
+        },
+        &SortFieldInfo{
+            Name: "email",
+            Unique: true,
+        },
+        &SortFieldInfo{
+            Name: "display_name",
+            Unique: false,
+            Aliases: []string{
+                "name",
+                "display name",
+                "display_name",
+            },
+        },
     }
 
     // Test with a non-aliased field for sorting
@@ -144,7 +151,7 @@ func TestNormalizeSortFields(t *testing.T) {
         },
     }
 
-    err := NormalizeSortFields(opts, &validSortFields, &sortFieldAliases)
+    err := NormalizeSortFields(opts, &sortFieldInfos)
     assert.Nil(err)
 
     // Test with an aliased field for sorting and check that the Field has been
@@ -158,7 +165,7 @@ func TestNormalizeSortFields(t *testing.T) {
         },
     }
 
-    err = NormalizeSortFields(opts, &validSortFields, &sortFieldAliases)
+    err = NormalizeSortFields(opts, &sortFieldInfos)
     assert.Nil(err)
 
     assert.Equal("display_name", opts.SortFields[0].Field)
@@ -173,6 +180,6 @@ func TestNormalizeSortFields(t *testing.T) {
         },
     }
 
-    err = NormalizeSortFields(opts, &validSortFields, &sortFieldAliases)
+    err = NormalizeSortFields(opts, &sortFieldInfos)
     assert.NotNil(err)
 }


### PR DESCRIPTION
Fixes Issue #111 by updating the bootstrap command to understand the errors.NOT_FOUND now returned by the user get operation.

Partially addresses Issue #109 by refactoring the sqlutil.NormalizeSortFields() function to accept a list of SortFieldInfo structs that describe sort field uniqueness and aliases.