### PR TITLE
Update a number of role and user-related methods to use sqlb

### DIFF
--- a/pkg/iam/iamstorage/role.go
+++ b/pkg/iam/iamstorage/role.go
@@ -377,9 +377,15 @@ func (s *IAMStorage) roleIdFromIdentifier(
 func (s *IAMStorage) roleIdFromUuid(
     uuid string,
 ) int {
-    qs := "SELECT id FROM roles WHERE uuid = ?"
+    m := s.Meta()
+    rtbl := m.TableDef("roles").As("r")
+    colRoleId := rtbl.Column("id")
+    colRoleUuid := rtbl.Column("uuid")
 
-    rows, err := s.Rows(qs, uuid)
+    q := sqlb.Select(colRoleId).Where(sqlb.Equal(colRoleUuid, uuid))
+    qs, qargs := q.StringArgs()
+
+    rows, err := s.Rows(qs, qargs...)
     if err != nil {
         return -1
     }

--- a/pkg/iam/iamstorage/role.go
+++ b/pkg/iam/iamstorage/role.go
@@ -347,10 +347,13 @@ func (s *IAMStorage) roleIdFromIdentifier(
     identifier string,
 ) int64 {
     var err error
-    qargs := make([]interface{}, 0)
-    qs := "SELECT id FROM roles WHERE "
-    qs = buildRoleGetWhere(qs, identifier, &qargs)
+    m := s.Meta()
+    rtbl := m.TableDef("roles").As("r")
+    colRoleId := rtbl.Column("id")
 
+    q := sqlb.Select(colRoleId)
+    s.roleWhere(q, identifier)
+    qs, qargs := q.StringArgs()
     rows, err := s.Rows(qs, qargs...)
     if err != nil {
         return 0
@@ -390,6 +393,28 @@ func (s *IAMStorage) roleIdFromUuid(
     }
     return roleId
 }
+
+func (s *IAMStorage) roleWhere(
+    q *sqlb.SelectQuery,
+    search string,
+) {
+    m := s.Meta()
+    rtbl := m.TableDef("roles").As("r")
+    colRoleDisplayName := rtbl.Column("display_name")
+    colRoleUuid := rtbl.Column("uuid")
+    colRoleSlug := rtbl.Column("slug")
+    if util.IsUuidLike(search) {
+        q.Where(sqlb.Equal(colRoleUuid, util.UuidFormatDb(search)))
+    } else {
+        q.Where(
+            sqlb.Or(
+                sqlb.Equal(colRoleDisplayName, search),
+                sqlb.Equal(colRoleSlug, search),
+            ),
+        )
+    }
+}
+
 
 // TODO(jaypipes): Consolidate this and the org/user ones into a generic
 // buildGenericWhere() helper function

--- a/pkg/iam/iamstorage/role.go
+++ b/pkg/iam/iamstorage/role.go
@@ -445,13 +445,14 @@ func buildRoleGetWhere(
 func (s *IAMStorage) rolePermissionsById(
     roleId int64,
 ) ([]pb.Permission, error) {
-    qs := `
-SELECT
-  rp.permission
-FROM role_permissions AS rp
-WHERE rp.role_id = ?
-`
-    rows, err := s.Rows(qs, roleId)
+    m := s.Meta()
+    rptbl := m.TableDef("role_permissions").As("rp")
+    colPermission := rptbl.Column("permission")
+    colRoleId := rptbl.Column("role_id")
+
+    q := sqlb.Select(colPermission).Where(sqlb.Equal(colRoleId, roleId))
+    qs, qargs := q.StringArgs()
+    rows, err := s.Rows(qs, qargs...)
     if err != nil {
         return nil, err
     }


### PR DESCRIPTION
Update the following methods of the IAMStorage struct to use sqlb instead of manual SQL string construction:

* roleIdFromIdentifier()
* roleIdFromUuid()
* rolePermissionsById()
* usersInOrgTreeExcluding()

Issue #114