### PR TITLE
Update more user-related methods to use sqlb

### DIFF
--- a/p7n/commands/organization_members.go
+++ b/p7n/commands/organization_members.go
@@ -33,8 +33,9 @@ func orgMembers(cmd *cobra.Command, args []string) {
 
     if len(args) == 1 {
         orgMembersList(cmd, orgMembersOrgId)
+    } else {
+        orgMembersSet(cmd, orgMembersOrgId, args[1:len(args)])
     }
-    orgMembersSet(cmd, orgMembersOrgId, args[1:len(args)])
 }
 
 func orgMembersSet(cmd *cobra.Command, orgId string, args []string) {

--- a/p7n/commands/user_roles.go
+++ b/p7n/commands/user_roles.go
@@ -34,8 +34,9 @@ func userRoles(cmd *cobra.Command, args []string) {
     userRolesUserId = args[0]
     if len(args) == 1 {
         userRolesList(cmd, userRolesUserId)
+    } else {
+        userRolesSet(cmd, userRolesUserId, args[1:len(args)])
     }
-    userRolesSet(cmd, userRolesUserId, args[1:len(args)])
 }
 
 func userRolesSet(cmd *cobra.Command, userId string, args []string) {

--- a/pkg/iam/iamstorage/user.go
+++ b/pkg/iam/iamstorage/user.go
@@ -165,7 +165,7 @@ func (s *IAMStorage) usersInOrgTreeExcluding(
     q.Where(
         sqlb.And(
             sqlb.Equal(colRootOrgId, rootOrgId),
-            sqlb.Equal(colOUUserId, excludeUserId),
+            sqlb.NotEqual(colOUUserId, excludeUserId),
         ),
     )
     qs, qargs := q.StringArgs()

--- a/pkg/iam/iamstorage/user.go
+++ b/pkg/iam/iamstorage/user.go
@@ -547,45 +547,11 @@ func buildUserGetWhere(
 func (s *IAMStorage) UserGet(
     search string,
 ) (*pb.User, error) {
-    qargs := make([]interface{}, 0)
-    qs := `
-SELECT
-  uuid
-, email
-, display_name
-, slug
-, generation
-FROM users
-WHERE `
-    qs = buildUserGetWhere(qs, search, &qargs)
-
-    rows, err := s.Rows(qs, qargs...)
+    urec, err := s.userRecord(search)
     if err != nil {
         return nil, err
     }
-    defer rows.Close()
-    found := false
-    user := &pb.User{}
-    for rows.Next() {
-        if found {
-            return nil, errors.TOO_MANY_MATCHES(search)
-        }
-        err = rows.Scan(
-            &user.Uuid,
-            &user.Email,
-            &user.DisplayName,
-            &user.Slug,
-            &user.Generation,
-        )
-        if err != nil {
-            return nil, err
-        }
-        found = true
-    }
-    if ! found {
-        return nil, errors.NOTFOUND("user", search)
-    }
-    return user, nil
+    return urec.pb, nil
 }
 
 // Creates a new record for a user

--- a/pkg/iam/iamstorage/user.go
+++ b/pkg/iam/iamstorage/user.go
@@ -426,11 +426,12 @@ func (s *IAMStorage) userUuidFromIdentifier(
     identifier string,
 ) string {
     var err error
-    qargs := make([]interface{}, 0)
-    qs := `
-SELECT uuid FROM users
-WHERE `
-    qs = buildUserGetWhere(qs, identifier, &qargs)
+    m := s.Meta()
+    utbl := m.TableDef("users").As("u")
+    colUserUuid := utbl.Column("uuid")
+    q := sqlb.Select(colUserUuid)
+    s.userWhere(q, identifier)
+    qs, qargs := q.StringArgs()
 
     rows, err := s.Rows(qs, qargs...)
     if err != nil {


### PR DESCRIPTION
Updates a number of IAMStorage methods to use sqlb instead of manual SQL string construction:

* usersInOrgExcluding()
* userIdFromIdentifier()
* userUuidFromIdentifier()
* userRecord()
* UserGet()
* UserMembersList()
* UserRolesList()

Issue #114 