### PR TITLE
First phase updating organization methods to use sqlb

### DIFF
--- a/pkg/iam/iamstorage/organization.go
+++ b/pkg/iam/iamstorage/organization.go
@@ -516,12 +516,12 @@ func (s *IAMStorage) orgIdFromIdentifier(identifier string) int64 {
 // Given an identifier (slug or UUID), return the organization's root
 // integer ID. Returns 0 if the organization could not be found.
 func (s *IAMStorage) rootOrgIdFromIdentifier(identifier string) uint64 {
-    qargs := make([]interface{}, 0)
-    qs := `
-SELECT root_organization_id
-FROM organizations
-WHERE `
-    qs = orgBuildWhere(qs, identifier, &qargs)
+    m := s.Meta()
+    otbl := m.TableDef("organizations").As("o")
+    colRootOrgId := otbl.Column("root_organization_id")
+    q := sqlb.Select(colRootOrgId)
+    s.orgWhere(q, identifier)
+    qs, qargs := q.StringArgs()
 
     rows, err := s.Rows(qs, qargs...)
     if err != nil {

--- a/pkg/iam/iamstorage/role.go
+++ b/pkg/iam/iamstorage/role.go
@@ -171,7 +171,6 @@ func (s *IAMStorage) RoleGet(
     search string,
 ) (*pb.Role, error) {
     m := s.Meta()
-    qargs := make([]interface{}, 0)
     rtbl := m.TableDef("roles").As("r")
     otbl := m.TableDef("organizations").As("o")
     colRoleDisplayName := rtbl.Column("display_name")

--- a/pkg/iam/iamstorage/role.go
+++ b/pkg/iam/iamstorage/role.go
@@ -421,26 +421,6 @@ func (s *IAMStorage) roleWhere(
     }
 }
 
-
-// TODO(jaypipes): Consolidate this and the org/user ones into a generic
-// buildGenericWhere() helper function
-// Builds the WHERE clause for single role search by identifier
-func buildRoleGetWhere(
-    qs string,
-    search string,
-    qargs *[]interface{},
-) string {
-    if util.IsUuidLike(search) {
-        qs = qs + "uuid = ?"
-        *qargs = append(*qargs, util.UuidFormatDb(search))
-    } else {
-        qs = qs + "display_name = ? OR slug = ?"
-        *qargs = append(*qargs, search)
-        *qargs = append(*qargs, search)
-    }
-    return qs
-}
-
 // Given a pb.Role message, populates the list of permissions for a specified role ID
 func (s *IAMStorage) rolePermissionsById(
     roleId int64,

--- a/pkg/iam/iamstorage/user.go
+++ b/pkg/iam/iamstorage/user.go
@@ -3,7 +3,6 @@ package iamstorage
 import (
     "fmt"
     "database/sql"
-    "strings"
 
     "github.com/gosimple/slug"
     "github.com/jaypipes/sqlb"
@@ -521,26 +520,6 @@ func (s *IAMStorage) userWhere(
             ),
         )
     }
-}
-
-// Builds the WHERE clause for single user search by identifier
-func buildUserGetWhere(
-    qs string,
-    search string,
-    qargs *[]interface{},
-) string {
-    if util.IsUuidLike(search) {
-        qs = qs + "uuid = ?"
-        *qargs = append(*qargs, util.UuidFormatDb(search))
-    } else if util.IsEmailLike(search) {
-        qs = qs + "email = ?"
-        *qargs = append(*qargs, strings.TrimSpace(search))
-    } else {
-        qs = qs + "display_name = ? OR slug = ?"
-        *qargs = append(*qargs, search)
-        *qargs = append(*qargs, search)
-    }
-    return qs
 }
 
 // Returns a pb.User record filled with information about a requested user.


### PR DESCRIPTION
Updates the following IAMStorage methods to use sqlb instead of constructing SQL strings manually:

* OrganizationGet()
* orgIdFromIdentifier()
* rootOrgIdFromIdentiifer()

Issue #114